### PR TITLE
Cache optimisé façon ROK4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "express-validator": "^6.5.0",
     "fs": "0.0.1-security",
     "geojson-validation": "^1.0.2",
+    "geotiff": "^1.0.0-beta.13",
     "jimp": "^0.14.0",
     "mocha": "^8.1.1",
     "nocache": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "swagger-editor-dist": "^3.10.0",
     "swagger-ui-dist": "^3.25.5",
     "swagger-ui-express": "^4.1.4",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "eslint": "^7.2.0",

--- a/scripts/GetCapabilitiesAndJson.py
+++ b/scripts/GetCapabilitiesAndJson.py
@@ -93,7 +93,7 @@ def export_capabilities(layers, url):
         source["networkOptions"] = {"crossOrigin": "anonymous"}
         source["format"] = layer['format']
         source["name"] = layer['name']
-        source["tileMatrixSet"] = "LAMBB93"
+        source["tileMatrixSet"] = "LAMB93"
         source["tileMatrixSetLimits"] = limits
         layerconf["source"] = source
         with open('itowns/'+layer['name']+".json", 'w') as outfile:

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -103,7 +103,7 @@ def process_image(tiles, db_graph, input_filename, color, out_raster_srs):
     input_image = gdal.Open(input_filename)
     stem = Path(input_filename).stem
     # for z in tiles:
-    for tile_z in range(14, 20):
+    for tile_z in range(10, 22):
         print('Niveau de zoom : ', tile_z)
         for tile_x in range(int(math.floor(tile_matix_set_limits[tile_z]['MinTileCol']/NBTILES)),
                             int(math.floor(tile_matix_set_limits[tile_z]['MaxTileCol']/NBTILES))+1):

--- a/serveur.js
+++ b/serveur.js
@@ -6,6 +6,7 @@ const bodyParser = require('body-parser');
 const swaggerUi = require('swagger-ui-express');
 const YAML = require('yamljs');
 const debug = require('debug');
+const { argv } = require('yargs');
 
 const PORT = 8081;
 
@@ -13,12 +14,7 @@ const nocache = require('nocache');
 
 const app = express();
 
-global.dir_cache = 'cache';
-// on charge les mtd du cache, en fonction de l'option de démarrage (test ou pas)
-// pour test, option "--cache_test"
-if (process.argv.indexOf('--cache_test') > 0) {
-  global.dir_cache = 'cache_test';
-}
+global.dir_cache = argv.cache ? argv.cache : 'cache';
 debug.log(`using cache directory: ${global.dir_cache}`);
 
 const wmts = require('./routes/wmts');


### PR DESCRIPTION
Pour info, j'ai commencé à faire un test de cache tuilé façon ROK4.
Par défaut, au lieu de stocker des images de 256x256, on fait des paquets de 16x16 tuiles (donc 4096x4096).
J'utilise du Tiff tuilé pour pouvoir accéder rapidement aux imagettes de 256x256.

C'est toujours en cours. 

- J'ai modifié le script de création de cache: c'est simple et je pense que ça fonctionne bien.
- J'ai aussi commencé à modifier le GetTile (je ne gère pas les modifs du GetFeatureInfo et des routes Graph pour le moment): ça commence à fonctionner mais c'est trop lent. 