### PR TITLE
Gestion port

### DIFF
--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -1,4 +1,3 @@
-// const { threshold } = require("jimp");
 
 class Saisie {
   constructor(options) {
@@ -108,7 +107,7 @@ class Saisie {
     const dataStr = JSON.stringify(geojson);
     view.scene.remove(this.currentMeasure);
     // On post le geojson sur l'API
-    fetch(`${this.apiUrl}patch?`,
+    fetch(`${this.apiUrl}/patch?`,
       {
         method: 'POST',
         headers: {
@@ -149,7 +148,7 @@ class Saisie {
         // on selectionne le cliche
         const pos = this.pickPoint(e);
         const that = this;
-        fetch(`${this.apiUrl}graph?x=${pos.x}&y=${pos.y}`,
+        fetch(`${this.apiUrl}/graph?x=${pos.x}&y=${pos.y}`,
           {
             method: 'GET',
             headers: {
@@ -251,7 +250,7 @@ class Saisie {
   undo() {
     this.message = "";
     console.log('undo');
-    fetch(`${this.apiUrl}patch/undo?`,
+    fetch(`${this.apiUrl}/patch/undo?`,
       {
         method: 'PUT',
       }).then((res) => {
@@ -283,7 +282,7 @@ class Saisie {
   redo() {
     this.message = "";
     console.log('redo');
-    fetch(`${this.apiUrl}patch/redo?`,
+    fetch(`${this.apiUrl}/patch/redo?`,
       {
         method: 'PUT',
       }).then((res) => {
@@ -312,7 +311,7 @@ class Saisie {
   clear() {
     this.message = "";
     console.log('clear');
-    fetch(`${this.apiUrl}patchs/clear?`,
+    fetch(`${this.apiUrl}/patchs/clear?`,
       {
         method: 'PUT',
       }).then((res) => {

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -165,6 +165,9 @@
             menuGlobe.addImageryLayersGUI(view.getLayers(function gui(l) { return l.isColorLayer; }));
             debug.createTileDebugUI(menuGlobe.gui, view);
         })
+        .catch ( (err) => {
+            prompt(`API non accessible a l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl)
+        })
     </script>
 </body>
 </html>

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -23,12 +23,17 @@
     <script src="node_modules/itowns/dist/debug.js"></script>
     <script src="Saisie.js"></script>
     <script type="text/javascript">
-        const apiUrl = 'http://localhost:8081/'
+        const urlParams = new URLSearchParams(window.location.search);
+        const server = urlParams.get('server') ? urlParams.get('server') : 'localhost';
+        const port = urlParams.get('port') ? urlParams.get('port') : 8081;
+        console.log(server, port)
+
+        apiUrl = "http://" + server + ":" + port
         // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
         itowns.proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
         /* global itowns, setupLoadingScreen, GuiTools, debug */
 
-        itowns.Fetcher.json(apiUrl+'json/overviews').then ((json) => {
+        itowns.Fetcher.json(apiUrl+'/json/overviews').then ((json) => {
             const overviews = json
 
             // limite du crs
@@ -74,7 +79,7 @@
 
             var orthoLayer, graphLayer;
             var orthoConfig, graphConfig;
-            let promises = [itowns.Fetcher.json(apiUrl+'json/ortho'), itowns.Fetcher.json(apiUrl+'json/graph'), itowns.Fetcher.json(apiUrl+'json/opi')];
+            let promises = [itowns.Fetcher.json(apiUrl+'/json/ortho'), itowns.Fetcher.json(apiUrl+'/json/graph'), itowns.Fetcher.json(apiUrl+'/json/opi')];
             Promise.all(promises).then((conf) => {
                 orthoConfig = conf[0];
                 graphConfig = conf[1];

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -166,7 +166,9 @@
             debug.createTileDebugUI(menuGlobe.gui, view);
         })
         .catch ( (err) => {
-            prompt(`API non accessible a l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl)
+            apiUrl = prompt(`API non accessible a l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl)
+            apiUrlSplit = apiUrl.split('/')[2].split(':')
+            window.location.assign(`http://localhost:8000/?serverapi=${apiUrlSplit[0]}&portapi=${apiUrlSplit[1]}`)
         })
     </script>
 </body>

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -166,7 +166,7 @@
             debug.createTileDebugUI(menuGlobe.gui, view);
         })
         .catch ( (err) => {
-            apiUrl = prompt(`API non accessible a l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl)
+            apiUrl = prompt(`API non accessible à l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl)
             apiUrlSplit = apiUrl.split('/')[2].split(':')
             window.location.assign(`http://localhost:8000/?serverapi=${apiUrlSplit[0]}&portapi=${apiUrlSplit[1]}`)
         })

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -24,11 +24,11 @@
     <script src="Saisie.js"></script>
     <script type="text/javascript">
         const urlParams = new URLSearchParams(window.location.search);
-        const server = urlParams.get('server') ? urlParams.get('server') : 'localhost';
-        const port = urlParams.get('port') ? urlParams.get('port') : 8081;
-        console.log(server, port)
+        const serverAPI = urlParams.get('serverapi') ? urlParams.get('serverapi') : 'localhost';
+        const portAPI = urlParams.get('portapi') ? urlParams.get('portapi') : 8081;
+        console.log(serverAPI, portAPI)
 
-        apiUrl = "http://" + server + ":" + port
+        apiUrl = "http://" + serverAPI + ":" + portAPI
         // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
         itowns.proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
         /* global itowns, setupLoadingScreen, GuiTools, debug */

--- a/serveur.js
+++ b/serveur.js
@@ -31,6 +31,7 @@ try {
 
   const PORT = argv.port ? argv.port : 8081;
   const SERVER = argv.server ? argv.server : os.hostname();
+  app.urlApi = `http://${SERVER}:${PORT}`;
   //  const PLATFORM = os.platform();
 
   // on charge les mtd du cache
@@ -86,15 +87,14 @@ try {
   };
 
   const swaggerDocument = YAML.load('./doc/swagger.yml');
-
   app.use('/doc', swaggerUi.serve, swaggerUi.setup(swaggerDocument, options));
+  swaggerDocument.info.version = '0.1.0';
+  swaggerDocument.servers[0].url = app.urlApi;
 
   app.use('/', wmts);
   app.use('/', graph);
   app.use('/', file);
   app.use('/', patch);
-
-  app.urlApi = `http://${SERVER}:${PORT}`;
 
   module.exports = app.listen(PORT, () => {
     debug.log(`URL de l'api : ${app.urlApi} \nURL de la documentation swagger : ${app.urlApi}/doc`);

--- a/serveur.js
+++ b/serveur.js
@@ -9,10 +9,23 @@ const YAML = require('yamljs');
 const debugServer = require('debug')('serveur');
 const debug = require('debug');
 const path = require('path');
-
-const { argv } = require('yargs');
-
 const nocache = require('nocache');
+
+const { argv } = require('yargs')
+  .version(false)
+  .option('cache', {
+    alias: 'c',
+    describe: "cache directory (default: 'cache')",
+  })
+  .option('port', {
+    alias: 'p',
+    describe: "API port (default: '8081')",
+  })
+  .option('server', {
+    alias: 's',
+    describe: "API server (default: 'localhost')",
+  })
+  .help();
 
 const app = express();
 

--- a/serveur.js
+++ b/serveur.js
@@ -26,9 +26,7 @@ const { argv } = require('yargs')
     describe: "API server (default: 'localhost')",
   })
   .help()
-  .alias('help', 'h')
-  ;
-
+  .alias('help', 'h');
 
 const app = express();
 

--- a/serveur.js
+++ b/serveur.js
@@ -25,7 +25,10 @@ const { argv } = require('yargs')
     alias: 's',
     describe: "API server (default: 'localhost')",
   })
-  .help();
+  .help()
+  .alias('help', 'h')
+  ;
+
 
 const app = express();
 


### PR DESCRIPTION
1) Gestion du 'port' et du 'server' de manière dynamique : pour l'API, le swagger et itowns
2) Ajout d'une aide pour l'API (serveur.js --help)

Modification : Suppresion du '\\' final dans l'url de l'API dans itowns