### PR TITLE
Opi Select 2

### DIFF
--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -238,6 +238,8 @@ class Saisie {
             if (res.status == 201) {
               console.log("out of bounds")
               this.opiLayer.visible = false;
+              this.validClicheSelected = false;
+              this.controllers['cliche'].__li.style.backgroundColor = '';
               view.notifyChange(this.opiLayer,true);
             }
           });
@@ -273,9 +275,9 @@ class Saisie {
     console.log('"select": En attente de sélection');
     this.currentStatus = status.MOVE_POINT;
     // this.cliche = null;
-    this.controllers['cliche'].__li.style.backgroundColor = '';
+    //this.controllers['cliche'].__li.style.backgroundColor = '';
     this.message = 'choisir un cliche';
-    this.validClicheSelected = false;
+    // this.validClicheSelected = false;
     // this.opiLayer.visible = false;
     // view.notifyChange(this.opiLayer,true);
   }
@@ -291,6 +293,7 @@ class Saisie {
       // saisie deja en cours
       return;
     }
+    this.controllers['select'].__li.style.backgroundColor = '';
     this.controllers['polygon'].__li.style.backgroundColor = '#FF000055';
     document.getElementById("viewerDiv").style.cursor="crosshair";
     console.log("saisie d'un polygon");

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -285,7 +285,7 @@ class Saisie {
   polygon() {
     if (this.currentStatus === status.EN_COURS) return;
     if (!this.validClicheSelected){
-      this.message = 'pas de cliche valide';
+      this.message = (this.currentStatus == status.MOVE_POINT) ? 'choisir un cliche valide' : 'cliche non valide';
       return;
     }
     if (this.currentMeasure){

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -237,8 +237,6 @@ class Saisie {
             }
             if (res.status == 201) {
               console.log("out of bounds")
-              this.opiLayer.visible = false;
-              view.notifyChange(this.opiLayer,true);
             }
           });
         });
@@ -276,6 +274,8 @@ class Saisie {
     this.controllers['cliche'].__li.style.backgroundColor = '';
     this.message = 'choisir un cliche';
     this.validClicheSelected = false;
+    this.opiLayer.visible = false;
+    view.notifyChange(this.opiLayer,true);
   }
 
   polygon() {

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -237,6 +237,8 @@ class Saisie {
             }
             if (res.status == 201) {
               console.log("out of bounds")
+              this.opiLayer.visible = false;
+              view.notifyChange(this.opiLayer,true);
             }
           });
         });
@@ -270,12 +272,12 @@ class Saisie {
     document.getElementById("viewerDiv").style.cursor="crosshair";
     console.log('"select": En attente de sélection');
     this.currentStatus = status.MOVE_POINT;
-    this.cliche = null;
+    // this.cliche = null;
     this.controllers['cliche'].__li.style.backgroundColor = '';
     this.message = 'choisir un cliche';
     this.validClicheSelected = false;
-    this.opiLayer.visible = false;
-    view.notifyChange(this.opiLayer,true);
+    // this.opiLayer.visible = false;
+    // view.notifyChange(this.opiLayer,true);
   }
 
   polygon() {

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -135,7 +135,7 @@
                 var saisie = new Saisie({ graphLayer, orthoLayer, graphConfig, orthoConfig, opiLayer, opiConfig, apiUrl });
                 saisie.cliche = 'unknown';
                 saisie.message = '';
-                saisie.coord = 'xxx';
+                saisie.coord = `${((xmax + xmin) * 0.5).toFixed(2)} ${((ymax + ymin) * 0.5).toFixed(2)}`;
                 saisie.color = [0, 0, 0];
                 saisie.controllers = {};
                 saisie.controllers['select'] = menuGlobe.gui.add(saisie, 'select');


### PR DESCRIPTION
Modification du select et de l'interaction 'select' et 'polygon' : 

- cliquer sur 'select' n'efface pas le 'cliche' en cours

- cliquer sur 'polygon' alors que 'select' est actif, active la fonction de saisie uniquement dans le cas d'un cliche valide préalablement sélectionné


bonus : coords initiales définies sur le point centrale de la scene