### PR TITLE
[itowns] Fix reload sur serveur not localhost

### DIFF
--- a/itowns/index.html
+++ b/itowns/index.html
@@ -237,7 +237,7 @@
         .catch ( (err) => {
             apiUrl = prompt(`API non accessible à l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl)
             apiUrlSplit = apiUrl.split('/')[2].split(':')
-            window.location.assign(`http://localhost:8000/?serverapi=${apiUrlSplit[0]}&portapi=${apiUrlSplit[1]}`)
+            window.location.assign(`${window.location.origin}?serverapi=${apiUrlSplit[0]}&portapi=${apiUrlSplit[1]}`)
         })
     </script>
 </body>


### PR DESCRIPTION
Il y avait un bug lors du rechargement de la page itowns lorsqu'il arrive pas a contacter l'API, du au fait que localhost:8000 était écris en dur.

