### PR TITLE
version multithread des patchs

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -18,7 +18,7 @@ jobs:
       run: npm install
     - name: test
       env:
-        DEBUG:
+        DEBUG: patch
       run: |
         npm run test-coveralls
 

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -16,15 +16,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: install
       run: npm install
-      
-    - name: test
-      env:
-        DEBUG: patch
-      run: npx mocha test -c cache_test
-      
+            
     - name: test coveralls
       env:
-        DEBUG: patch
+        DEBUG: 
       run: |
         git checkout cache_test
         npm run test-coveralls

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -16,10 +16,17 @@ jobs:
     - uses: actions/checkout@v2
     - name: install
       run: npm install
+      
     - name: test
       env:
         DEBUG: patch
+      run: npx mocha test -c cache_test
+      
+    - name: test coveralls
+      env:
+        DEBUG: patch
       run: |
+        git checkout cache_test
         npm run test-coveralls
 
     - name: Coveralls

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "swagger-editor-dist": "^3.10.0",
     "swagger-ui-dist": "^3.25.5",
     "swagger-ui-express": "^4.1.4",
+    "workerpool": "^6.0.3",
     "xml2js": "^0.4.23",
     "yamljs": "^0.3.0",
     "yargs": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "serveur.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "nyc --reporter=text mocha --cache cache_test",
-    "test-coveralls": "nyc --reporter=lcov --report-dir=coverage mocha --cache cache_test"
+    "test": "c8 -r text mocha --cache cache_test",
+    "test-coveralls": "c8 -r lcov --report-dir=coverage mocha --cache cache_test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/gmaillet/ign-api-mosaique#readme",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "c8": "^7.3.5",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "chai-json-schema": "^1.5.1",
@@ -29,10 +30,10 @@
     "express-validator": "^6.5.0",
     "fs": "0.0.1-security",
     "geojson-validation": "^1.0.2",
+    "git-describe": "^4.0.4",
     "jimp": "^0.14.0",
     "mocha": "^8.1.1",
     "nocache": "^2.1.0",
-    "nyc": "^15.1.0",
     "proj4": "^2.6.2",
     "pureimage": "^0.2.1",
     "supervisor": "^0.12.0",
@@ -42,8 +43,7 @@
     "workerpool": "^6.0.3",
     "xml2js": "^0.4.23",
     "yamljs": "^0.3.0",
-    "yargs": "^15.4.1",
-    "git-describe": "^4.0.4"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "eslint": "^7.2.0",

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -235,6 +235,11 @@ router.post('/patch', encapBody.bind({ keyName: 'geoJSON' }), [
 
   const tiles = getTiles(geoJson.features, overviews);
   debug(tiles.length, 'tuiles intersectées');
+  if (tiles.length > global.minJobForWorkers) {
+    debug('on va utiliser de workers');
+  } else {
+    debug('on reste en monothread');
+  }
 
   try {
     // Patch these tiles
@@ -263,6 +268,7 @@ router.post('/patch', encapBody.bind({ keyName: 'geoJSON' }), [
     }));
 =======
 
+<<<<<<< HEAD
       promises.push(req.app.workerpool.exec(processTile,
         [global.dir_cache, tile, newPatchId, overviews, geoJson]).catch((error) => {
         if ((error.message !== 'Pool terminated')
@@ -271,6 +277,27 @@ router.post('/patch', encapBody.bind({ keyName: 'geoJSON' }), [
         }
       }));
 >>>>>>> partial fix for tests
+=======
+      if (tiles.length > global.minJobForWorkers) {
+        // on utilise des workers
+        promises.push(req.app.workerpool.exec(processTile,
+          [global.dir_cache, tile, newPatchId, overviews, geoJson]).catch((error) => {
+          if ((error.message !== 'Pool terminated')
+                && (error.message !== 'Worker terminated')) {
+            debug('Worker error : ', error);
+          }
+        }));
+      } else {
+        // on utise de simple promise
+        promises.push(processTile(global.dir_cache,
+          tile,
+          newPatchId,
+          overviews,
+          geoJson).catch((error) => {
+          debug('error : ', error);
+        }));
+      }
+>>>>>>> adaptation de la strategie en fonction de la taille du patch
     });
     debug(outOfBoundsTiles);
     if (outOfBoundsTiles.length) {

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -2,7 +2,7 @@ const debug = require('debug')('patch');
 const router = require('express').Router();
 const fs = require('fs');
 const path = require('path');
-const jimp = require('jimp');
+// const jimp = require('jimp');
 const { body, matchedData } = require('express-validator');
 const GJV = require('geojson-validation');
 // const PImage = require('pureimage');
@@ -95,6 +95,7 @@ function getTiles(features, overviews) {
   return tiles;
 }
 
+<<<<<<< HEAD
 async function processTile(dir_cache, tile, newPatchId, overviews, geoJson) {
 /* eslint-disable global-require */
   const debug = require('debug')('patch');
@@ -103,9 +104,18 @@ async function processTile(dir_cache, tile, newPatchId, overviews, geoJson) {
   const jimp = require('jimp');
   const fs = require('fs');
   /* eslint-disable global-require */
+=======
+async function processTile(dirCache, tile, newPatchId, overviews, geoJson) {
+  /* eslint-disable global-require */
+  const processDebug = require('debug')('patch');
+  const processPath = require('path');
+  const PImage = require('pureimage');
+  const jimp = require('jimp');
+  /* eslint-enable global-require */
+>>>>>>> fix Lint
 
-  debug("process ", tile);
-  const tileDir = path.join(dir_cache, tile.z, tile.y, tile.x);
+  processDebug('process ', tile);
+  const tileDir = processPath.join(dirCache, tile.z, tile.y, tile.x);
   const tileWidth = overviews.tileSize.width;
   const tileHeight = overviews.tileSize.height;
   const Rmax = overviews.resolution;
@@ -114,18 +124,18 @@ async function processTile(dir_cache, tile, newPatchId, overviews, geoJson) {
   const yOrigin = overviews.crs.boundingBox.ymax;
   const promises = [];
 
-  const urlGraph = path.join(tileDir, 'graph.png');
-  const urlOrtho = path.join(tileDir, 'ortho.png');
-  const urlOpi = path.join(tileDir, `${geoJson.features[0].properties.cliche}.png`);
-  const urlGraphOutput = path.join(tileDir, `graph_${newPatchId}.png`);
-  const urlOrthoOutput = path.join(tileDir, `ortho_${newPatchId}.png`);
+  const urlGraph = processPath.join(tileDir, 'graph.png');
+  const urlOrtho = processPath.join(tileDir, 'ortho.png');
+  const urlOpi = processPath.join(tileDir, `${geoJson.features[0].properties.cliche}.png`);
+  const urlGraphOutput = processPath.join(tileDir, `graph_${newPatchId}.png`);
+  const urlOrthoOutput = processPath.join(tileDir, `ortho_${newPatchId}.png`);
 
   // Il y a parfois un bug sur le dessin du premier pixel
   // on cree donc un masque une ligne de plus
   const mask = PImage.make(tileWidth, tileHeight + 1);
   const ctx = mask.getContext('2d');
   geoJson.features.forEach((feature) => {
-    // debug(feature.properties.color);
+    // processDebug(feature.properties.color);
     ctx.fillStyle = '#FFFFFF';
     ctx.beginPath();
     let first = true;
@@ -177,7 +187,7 @@ async function processTile(dir_cache, tile, newPatchId, overviews, geoJson) {
     }
     return graph.writeAsync(urlGraphOutput);
   }).then(() => {
-    debug('graph done');
+    processDebug('graph done');
   }));
 
   // On patch l ortho
@@ -195,13 +205,16 @@ async function processTile(dir_cache, tile, newPatchId, overviews, geoJson) {
     }
     return ortho.writeAsync(urlOrthoOutput);
   }).then(() => {
-    debug('ortho done');
+    processDebug('ortho done');
   }));
   await Promise.all(promises);
+<<<<<<< HEAD
   return true;
   // .then(() => {
   //   debug('traitement de la tuile terminé : ', tileDir);
   // })
+=======
+>>>>>>> fix Lint
 }
 
 router.get('/patchs', [], (req, res) => {

--- a/serveur.js
+++ b/serveur.js
@@ -104,7 +104,7 @@ try {
 
   // Creation d'un pool de workers pour traiter les calculs lourds (patchs)
   // par defaut, autant de workers que de coeurs sur la machine
-  app.workerpool = workerpool.pool();
+  app.workerpool = workerpool.pool({ minWorkers: 1 });
   debug.log(app.workerpool.stats());
 
   // swaggerDocument global var because needed in routes/misc.js
@@ -122,6 +122,7 @@ try {
   module.exports = app.listen(PORT, () => {
     debug.log(`URL de l'api : ${app.urlApi} \nURL de la documentation swagger : ${app.urlApi}/doc`);
   });
+  module.exports.workerpool = app.workerpool;
 } catch (err) {
   debug.log(err);
 }

--- a/serveur.js
+++ b/serveur.js
@@ -10,6 +10,7 @@ const debugServer = require('debug')('serveur');
 const debug = require('debug');
 const path = require('path');
 const nocache = require('nocache');
+const workerpool = require('workerpool');
 
 const { argv } = require('yargs')
   .version(false)
@@ -100,6 +101,11 @@ try {
   const options = {
     customCss: '.swagger-ui .topbar { display: none }',
   };
+
+  // Creation d'un pool de workers pour traiter les calculs lourds (patchs)
+  // par defaut, autant de workers que de coeurs sur la machine
+  app.workerpool = workerpool.pool();
+  debug.log(app.workerpool.stats());
 
   // swaggerDocument global var because needed in routes/misc.js
   global.swaggerDocument = YAML.load('./doc/swagger.yml');

--- a/serveur.js
+++ b/serveur.js
@@ -34,6 +34,8 @@ const app = express();
 global.dir_cache = argv.cache ? argv.cache : 'cache';
 debug.log(`using cache directory: ${global.dir_cache}`);
 
+global.minJobForWorkers = 20;
+
 const wmts = require('./routes/wmts.js');
 const graph = require('./routes/graph.js');
 const file = require('./routes/file.js');

--- a/test/patch.js
+++ b/test/patch.js
@@ -47,7 +47,7 @@ describe('Patch', () => {
 
             done();
           });
-      });
+      }).timeout(10000);
       // TODO gestion des polygones Out of bounds
       it("should get an error: 'File(s) missing", (done) => {
         chai.request(server)

--- a/test/patch.js
+++ b/test/patch.js
@@ -8,6 +8,7 @@ const server = require('..');
 
 describe('Patch', () => {
   after((done) => {
+    server.workerpool.terminate();
     server.close();
     done();
   });


### PR DESCRIPTION
A tester: j'ai fait une version multithread de l'application des patchs (intéressant dès que la zone est étendue). Normalement cela doit utiliser, par défaut, tous les coeurs dispo sur la machine.