### PR TITLE
Create cache multi

### DIFF
--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -14,8 +14,6 @@ from collections import defaultdict
 import multiprocessing
 cpu_dispo = multiprocessing.cpu_count()
 
-os.environ['PROJ_LIB'] = 'C:\\Users\\ftoromanoff\\AppData\\Local\\Programs\\Python\\Python37-32\\Lib\\site-packages\\osgeo\\data\\proj'
-
 parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--cache", help="cache directory (default: cache)", type=str, default="cache")
 parser.add_argument("-o", "--overviews", help="params for the mosaic (default: ressources/LAMB93_5cm.json)", type=str, default="ressources/LAMB93_5cm.json")

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -376,17 +376,13 @@ def main():
     print(" Calcul")
     nb_tiles = len(args_create_ortho_and_graph)
     print(" ", nb_tiles, "tuiles à traiter")
-    print("   ", end='', flush=True)
 
     counter = 0
     nb_steps = 20
-    nb_underscores = nb_steps
-    if (nb_tiles < nb_steps):
-        nb_underscores = nb_tiles
-    
-    for i in range(nb_underscores):
-        print("_", end='', flush=True)
-    print("")
+    if nb_tiles < nb_steps:
+        nb_steps = nb_tiles
+
+    print(" " + nb_steps * "_")
 
     for i in range(nb_tiles):
         args_create_ortho_and_graph[i]['advancement'] = 0
@@ -394,7 +390,7 @@ def main():
             counter = counter + 1
             args_create_ortho_and_graph[i]['advancement'] = counter * nb_steps
     
-    print('  |', end='', flush=True)
+    print('|', end='', flush=True)
     POOL = multiprocessing.Pool(cpu_dispo-1)
     POOL.map(create_ortho_and_graph_1arg, args_create_ortho_and_graph)
 

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -193,13 +193,14 @@ def create_ortho_and_graph_1arg(arguments):
     overviews = arguments['overviews']
     conn_string = arguments['conn_string']
     out_srs = arguments['out_srs']
+    advancement = arguments['advancement']
+
+    if advancement != 0:
+        print("  ",advancement,"% terminée")
 
     tile_x = tile['x']
     tile_y = tile['y']
     tile_z = tile['z']
-
-    print("*",end='')
-    #print("  level :", str(tile_z), "- tuile", tile_x, tile_y)
 
     resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - tile_z)
 
@@ -371,6 +372,15 @@ def main():
                 args_create_ortho_and_graph.append(argument_zyx)
 
     print(" Calcul")
+    nb_tiles = len(args_create_ortho_and_graph)
+    print(" ", nb_tiles, "tuiles a traitées")
+
+    counter = 0
+    for i in range(nb_tiles):
+        args_create_ortho_and_graph[i]['advancement'] = 0
+        if ( math.floor(i%(nb_tiles * 0.1)) == 0 ):
+            counter = counter + 1
+            args_create_ortho_and_graph[i]['advancement'] = counter * 10
 
     POOL = multiprocessing.Pool(cpu_dispo-1)
     POOL.map(create_ortho_and_graph_1arg, args_create_ortho_and_graph)
@@ -378,7 +388,7 @@ def main():
     POOL.close()
     POOL.join()
 
-    print('\n=> DONE')
+    print('=> DONE')
 
     #Finitions
     with open(args.cache+'/cache_mtd.json', 'w') as outfile:

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -376,16 +376,25 @@ def main():
     print(" Calcul")
     nb_tiles = len(args_create_ortho_and_graph)
     print(" ", nb_tiles, "tuiles à traiter")
+    print("   ", end='', flush=True)
 
     counter = 0
     nb_steps = 20
+    nb_underscores = nb_steps
+    if (nb_tiles < nb_steps):
+        nb_underscores = nb_tiles
+    
+    for i in range(nb_underscores):
+        print("_", end='', flush=True)
+    print("")
+
     for i in range(nb_tiles):
         args_create_ortho_and_graph[i]['advancement'] = 0
         if ( math.floor(i%(nb_tiles / nb_steps )) == 0 ):
             counter = counter + 1
             args_create_ortho_and_graph[i]['advancement'] = counter * nb_steps
     
-    print('|', end='', flush=True)
+    print('  |', end='', flush=True)
     POOL = multiprocessing.Pool(cpu_dispo-1)
     POOL.map(create_ortho_and_graph_1arg, args_create_ortho_and_graph)
 

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -476,8 +476,8 @@ def main():
                 argument4process.append(argument_zyx)
 
     print(" Calcul")
-    POOL = multiprocessing.Pool(cpu_dispo-1)
 
+    POOL = multiprocessing.Pool(cpu_dispo-1)
     POOL.map(create_ortho_and_graph_1arg, argument4process)
 
     POOL.close()

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -3,16 +3,12 @@
 """This script create or update a cache from a list of OPI"""
 import os
 import math
-import xml.etree.ElementTree as ET
 from pathlib import Path
 import glob
-import json
 from random import randrange
 import numpy as np
 import gdal
 import argparse
-from collections import defaultdict
-
 import multiprocessing
 cpu_dispo = multiprocessing.cpu_count()
 
@@ -26,7 +22,7 @@ parser.add_argument("-v", "--verbose", help="verbose (default: 0)", type=int, de
 args = parser.parse_args()
 verbose = args.verbose
 if verbose > 0:
-    print("Arguments: ",args)
+    print("Arguments: ", args)
 
 user = os.getenv('PGUSER', default='postgres')
 host = os.getenv('PGHOST', default='localhost')
@@ -35,8 +31,8 @@ password = os.getenv('PGPASSWORD', default='postgres')  # En dur, pas top...
 port = os.getenv('PGPORT', default='5432')
 
 nb_bands = 3
-
 PNG_DRIVER = gdal.GetDriverByName('png')
+
 
 def cut_opi_1tile(filename, tile_dir, image_name, origin, tileSize, tile, out_raster_srs, nb_bands):
     """Cut and reseample a specified image at a given level"""
@@ -44,7 +40,6 @@ def cut_opi_1tile(filename, tile_dir, image_name, origin, tileSize, tile, out_ra
         print("~~~cut_opi_1tile")
 
     input_image = gdal.Open(filename)
-    
     target_ds = gdal.GetDriverByName('MEM').Create('', tileSize['width'], tileSize['height'], nb_bands, gdal.GDT_Byte)
     target_ds.SetGeoTransform((origin['x'], tile['resolution'], 0, origin['y'], 0, -tile['resolution']))
     target_ds.SetProjection(out_raster_srs)
@@ -55,11 +50,12 @@ def cut_opi_1tile(filename, tile_dir, image_name, origin, tileSize, tile, out_ra
     gdal.Warp(opi, input_image)
 
     # on export en png (todo: gerer le niveau de Q)
-    dst_ds = PNG_DRIVER.CreateCopy(tile_dir +"/"+ image_name +".png", opi)
+    dst_ds = PNG_DRIVER.CreateCopy(tile_dir + "/" + image_name + ".png", opi)
     opi = None
     dst_ds = None
 
     return
+
 
 def create_blank_tile(overviews, tile, nb_bands, out_srs):
     """Return a blank georef image for a tile."""
@@ -74,6 +70,7 @@ def create_blank_tile(overviews, tile, nb_bands, out_srs):
     target_ds.FlushCache()
     return target_ds
 
+
 def get_tile_limits(filename):
     """Return tms limits for a georef image at a given level"""
     if verbose > 0:
@@ -84,12 +81,12 @@ def get_tile_limits(filename):
     ul_y = geo_trans[3]
     x_dist = geo_trans[1]
     y_dist = geo_trans[5]
-    lr_x = ul_x + src_image.RasterXSize*x_dist
-    lr_y = ul_y + src_image.RasterYSize*y_dist
+    lr_x = ul_x + src_image.RasterXSize * x_dist
+    lr_y = ul_y + src_image.RasterYSize * y_dist
 
     tile_limits = {}
-    tile_limits['LowerCorner'] = [ ul_x, lr_y ]
-    tile_limits['UpperCorner'] = [ lr_x, ul_y ]
+    tile_limits['LowerCorner'] = [ul_x, lr_y]
+    tile_limits['UpperCorner'] = [lr_x, ul_y]
 
     if verbose > 0:
         print(" DONE")
@@ -120,10 +117,10 @@ def get_tilebox(input_filename, overviews):
     for tile_z in range(overviews['level']['min'], overviews['level']['max'] + 1):
         resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - tile_z)
 
-        min_tile_col = math.floor(round((tile_limits['LowerCorner'][0] - overviews['crs']['boundingBox']['xmin'])/(resolution*overviews['tileSize']['width']),8))
-        min_tile_row = math.floor(round((overviews['crs']['boundingBox']['ymax']-tile_limits['UpperCorner'][1])/(resolution*overviews['tileSize']['height']),8))
-        max_tile_col = math.ceil(round((tile_limits['UpperCorner'][0] - overviews['crs']['boundingBox']['xmin'])/(resolution*overviews['tileSize']['width']),8)) - 1
-        max_tile_row =  math.ceil(round((overviews['crs']['boundingBox']['ymax']-tile_limits['LowerCorner'][1])/(resolution*overviews['tileSize']['height']),8)) - 1
+        min_tile_col = math.floor(round((tile_limits['LowerCorner'][0] - overviews['crs']['boundingBox']['xmin']) / (resolution * overviews['tileSize']['width']), 8))
+        min_tile_row = math.floor(round((overviews['crs']['boundingBox']['ymax'] - tile_limits['UpperCorner'][1]) / (resolution * overviews['tileSize']['height']), 8))
+        max_tile_col = math.ceil(round((tile_limits['UpperCorner'][0] - overviews['crs']['boundingBox']['xmin']) / (resolution * overviews['tileSize']['width']), 8)) - 1
+        max_tile_row = math.ceil(round((overviews['crs']['boundingBox']['ymax'] - tile_limits['LowerCorner'][1]) / (resolution * overviews['tileSize']['height']), 8)) - 1
 
         tilebox_z = {
             'MinTileCol': min_tile_col,
@@ -133,7 +130,7 @@ def get_tilebox(input_filename, overviews):
         }
         tilebox[str(tile_z)] = tilebox_z
 
-        if not( str(tile_z) in overviews['dataSet']['limits'] ):
+        if not(str(tile_z) in overviews['dataSet']['limits']):
             overviews['dataSet']['limits'][str(tile_z)] = {
                 'MinTileCol': min_tile_col,
                 'MinTileRow': min_tile_row,
@@ -152,6 +149,7 @@ def get_tilebox(input_filename, overviews):
 
     return tilebox
 
+
 def cut_image_1arg(arguments):
     """Cut a given image in all corresponding tiles for all level"""
     if verbose > 0:
@@ -164,27 +162,28 @@ def cut_image_1arg(arguments):
     nb_bands = arguments['nbBands']
 
     stem = Path(filename).stem
- 
+
     # for z in tiles:
     for tile_z in range(overviews['level']['min'], overviews['level']['max'] + 1):
-        print('  (',stem,') level :', tile_z)
+        print('  (', stem, ') level :', tile_z)
 
         resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - tile_z)
 
-        for tile_x in range(tilebox[str(tile_z)]['MinTileCol'], tilebox[str(tile_z)]['MaxTileCol'] + 1):    
+        for tile_x in range(tilebox[str(tile_z)]['MinTileCol'], tilebox[str(tile_z)]['MaxTileCol'] + 1):
             for tile_y in range(tilebox[str(tile_z)]['MinTileRow'], tilebox[str(tile_z)]['MaxTileRow'] + 1):
                 origin = {
                     'x': overviews['crs']['boundingBox']['xmin'] + tile_x * resolution * overviews['tileSize']['width'],
                     'y': overviews['crs']['boundingBox']['ymax'] - tile_y * resolution * overviews['tileSize']['height']
                 }
 
-                tile_dir = args.cache+'/'+str(tile_z)+'/'+str(tile_y)+'/'+str(tile_x)
+                tile_dir = args.cache + '/' + str(tile_z) + '/' + str(tile_y) + '/' + str(tile_x)
                 tile = {'x': tile_x, 'y': tile_y, 'resolution': resolution}
 
-                # si necessaire on cree le dossier de la tuile             
+                # si necessaire on cree le dossier de la tuile
                 Path(tile_dir).mkdir(parents=True, exist_ok=True)
 
                 cut_opi_1tile(filename, tile_dir, stem, origin, overviews['tileSize'], tile, out_srs, nb_bands)
+
 
 def create_ortho_and_graph_1arg(arguments):
     """Creation of the ortho and the graph images on a specified tile"""
@@ -210,22 +209,21 @@ def create_ortho_and_graph_1arg(arguments):
     ortho = create_blank_tile(overviews, {'x': tile_x, 'y': tile_y, 'resolution': resolution}, 3, out_srs)
     graph = create_blank_tile(overviews, {'x': tile_x, 'y': tile_y, 'resolution': resolution}, 3, out_srs)
 
-    tile_dir = args.cache+'/'+str(tile_z)+'/'+str(tile_y)+'/'+str(tile_x)
-    list_filename = glob.glob(tile_dir+'/*.png')
+    tile_dir = args.cache + '/' + str(tile_z) + '/' + str(tile_y) + '/' + str(tile_x)
+    list_filename = glob.glob(tile_dir + '/*.png')
 
     is_empty = True
 
     for filename in list_filename:
         stem = Path(filename).stem
-
         color = overviews["list_OPI"][stem]
-        
+
         # on cree une image mono canal pour la tuile
         mask = create_blank_tile(overviews, {'x': tile_x, 'y': tile_y, 'resolution': resolution}, 3, out_srs)
 
         # on rasterise la partie du graphe qui concerne ce cliche
         db_graph = gdal.OpenEx(conn_string, gdal.OF_VECTOR)
-        gdal.Rasterize(mask, db_graph, SQLStatement='select geom from ' + args.table + ' where cliche = \''+stem+'\' ')
+        gdal.Rasterize(mask, db_graph, SQLStatement='select geom from ' + args.table + ' where cliche = \'' + stem + '\' ')
         img_mask = mask.GetRasterBand(1).ReadAsArray()
         # si le mask est vide, on a termine
         val_max = np.amax(img_mask)
@@ -234,44 +232,45 @@ def create_ortho_and_graph_1arg(arguments):
 
             opi = gdal.Open(filename)
             for i in range(3):
-                opi_i = opi.GetRasterBand(i+1).ReadAsArray()
+                opi_i = opi.GetRasterBand(i + 1).ReadAsArray()
                 opi_i[(img_mask == 0)] = 0
 
-                ortho_i = ortho.GetRasterBand(i+1).ReadAsArray()
+                ortho_i = ortho.GetRasterBand(i + 1).ReadAsArray()
 
                 ortho_i[(img_mask != 0)] = 0
-                ortho.GetRasterBand(i+1).WriteArray(np.add(opi_i, ortho_i))
+                ortho.GetRasterBand(i + 1).WriteArray(np.add(opi_i, ortho_i))
 
-                graph_i = graph.GetRasterBand(i+1).ReadAsArray()
+                graph_i = graph.GetRasterBand(i + 1).ReadAsArray()
 
                 graph_i[(img_mask != 0)] = color[i]
-                graph.GetRasterBand(i+1).WriteArray(graph_i)
+                graph.GetRasterBand(i + 1).WriteArray(graph_i)
 
     if not is_empty:
-        dst_ortho = PNG_DRIVER.CreateCopy(tile_dir+"/ortho.png", ortho)
-        dst_graph = PNG_DRIVER.CreateCopy(tile_dir+"/graph.png", graph)
+        dst_ortho = PNG_DRIVER.CreateCopy(tile_dir + "/ortho.png", ortho)
+        dst_graph = PNG_DRIVER.CreateCopy(tile_dir + "/graph.png", graph)
         dst_ortho = None
         dst_graph = None
     ortho = None
     graph = None
-         
+
+
 def main():
     """Create or Update the cache for list of input OPI."""
     import shutil
     import json
 
     if os.path.isdir(args.input):
-        args.input = args.input + '\*.tif'
+        args.input = args.input + '\\*.tif'
 
     if not os.path.isdir(args.cache):
         # creation dossier cache
         os.mkdir(args.cache)
 
-    if not os.path.exists(args.cache+'/overviews.json'):
+    if not os.path.exists(args.cache + '/overviews.json'):
         # creation fichier overviews.json a partir d'un fichier ressource
-        shutil.copy2(args.overviews, args.cache+'/overviews.json')
+        shutil.copy2(args.overviews, args.cache + '/overviews.json')
 
-    with open(args.cache+'/overviews.json') as json_overviews:
+    with open(args.cache + '/overviews.json') as json_overviews:
         overviews_init = json.load(json_overviews)
         overviews_dict = overviews_init
     if not ("list_OPI" in overviews_dict):
@@ -282,21 +281,20 @@ def main():
         overviews_dict['dataSet']['boundingBox'] = {}
         overviews_dict['dataSet']['limits'] = {}
 
-
     out_raster_srs = gdal.osr.SpatialReference()
     out_raster_srs.ImportFromEPSG(overviews_init['crs']['code'])
     out_srs = out_raster_srs.ExportToWkt()
 
-    conn_string = "PG:host="+host+" dbname="+database+" user="+user+" password="+password
+    conn_string = "PG:host=" + host + " dbname=" + database + " user=" + user + " password=" + password
 
     list_filename = glob.glob(args.input)
     if verbose > 0:
         print(len(list_filename), "fichier(s) a traiter")
 
     try:
-        with open(args.cache+'/cache_mtd.json', 'r') as inputfile:
+        with open(args.cache + '/cache_mtd.json', 'r') as inputfile:
             mtd = json.load(inputfile)
-    except:
+    except ValueError:
         mtd = {}
 
     opi_already_calculated = []
@@ -307,7 +305,6 @@ def main():
     print(" Préparation")
     for filename in list_filename:
         opi = Path(filename).stem
-     
         if (opi in overviews_dict['list_OPI'].keys()):
             # OPI déja traitée
             opi_already_calculated.append(opi)
@@ -321,9 +318,8 @@ def main():
             if color[1] not in mtd[color[0]]:
                 mtd[color[0]][color[1]] = {}
             mtd[color[0]][color[1]][color[2]] = opi
- 
-            tilebox_image = get_tilebox(filename, overviews_init)
 
+            tilebox_image = get_tilebox(filename, overviews_init)
             argument_zyx = {
                 'filename': filename,
                 'outSrs': out_srs,
@@ -332,21 +328,21 @@ def main():
                 'nbBands': nb_bands
             }
 
-            args_cut_image.append(argument_zyx)  
+            args_cut_image.append(argument_zyx)
 
             # on ajout l'OPI traitée a la liste (avec sa couleur)
             overviews_dict["list_OPI"][opi] = color
-    
-    print(" Découpage" )
 
-    POOL = multiprocessing.Pool(cpu_dispo-1)
+    print(" Découpage")
+
+    POOL = multiprocessing.Pool(cpu_dispo - 1)
     POOL.map(cut_image_1arg, args_cut_image)
 
     POOL.close()
     POOL.join()
 
     print('=> DONE')
-    
+
     print("Génération du graph et de l'ortho (par tuile) :")
     db_graph = gdal.OpenEx(conn_string, gdal.OF_VECTOR)
     if db_graph is None:
@@ -355,14 +351,14 @@ def main():
     args_create_ortho_and_graph = []
 
     print(" Préparation")
-    
+
     # Calcul des ortho et graph
     for level in overviews_dict["dataSet"]["limits"]:
         print("  level :", level)
 
         level_limits = overviews_dict["dataSet"]["limits"][level]
 
-        for tile_x in range(level_limits["MinTileCol"], level_limits["MaxTileCol"] + 1):    
+        for tile_x in range(level_limits["MinTileCol"], level_limits["MaxTileCol"] + 1):
             for tile_y in range(level_limits["MinTileRow"], level_limits["MaxTileRow"] + 1):
 
                 argument_zyx = {
@@ -378,20 +374,20 @@ def main():
     print(" ", nb_tiles, "tuiles à traiter")
 
     counter = 0
-    nb_steps = 20
+    nb_steps = 50
     if nb_tiles < nb_steps:
         nb_steps = nb_tiles
 
-    print(" " + nb_steps * "_")
+    print("   " + nb_steps * "_")
 
     for i in range(nb_tiles):
         args_create_ortho_and_graph[i]['advancement'] = 0
-        if ( math.floor(i%(nb_tiles / nb_steps )) == 0 ):
+        if (math.floor(i % (nb_tiles / nb_steps)) == 0):
             counter = counter + 1
             args_create_ortho_and_graph[i]['advancement'] = counter * nb_steps
-    
-    print('|', end='', flush=True)
-    POOL = multiprocessing.Pool(cpu_dispo-1)
+
+    print('  |', end='', flush=True)
+    POOL = multiprocessing.Pool(cpu_dispo - 1)
     POOL.map(create_ortho_and_graph_1arg, args_create_ortho_and_graph)
 
     POOL.close()
@@ -400,16 +396,17 @@ def main():
     print('|')
     print('=> DONE')
 
-    #Finitions
-    with open(args.cache+'/cache_mtd.json', 'w') as outfile:
+    # Finitions
+    with open(args.cache + '/cache_mtd.json', 'w') as outfile:
         json.dump(mtd, outfile)
 
-    with open(args.cache+'/overviews.json', 'w') as outfile:
+    with open(args.cache + '/overviews.json', 'w') as outfile:
         json.dump(overviews_dict, outfile)
 
-    print("\n", len(list_filename) - len(opi_already_calculated),"/",len(list_filename),"OPI(s) ajoutée(s)")
+    print("\n", len(list_filename) - len(opi_already_calculated), "/", len(list_filename), "OPI(s) ajoutée(s)")
     if len(opi_already_calculated) > 0:
         print(opi_already_calculated, "déjà traitées : OPI non recalculée(s)")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -297,18 +297,18 @@ def main():
     except:
         mtd = {}
 
-    cliche_already_calculated = []
+    opi_already_calculated = []
 
     args_cut_image = []
     # Decoupage des images et calcul de l'emprise globale
     print("Découpe des images :")
     print(" Préparation")
     for filename in list_filename:
-        cliche = Path(filename).stem
+        opi = Path(filename).stem
      
-        if (cliche in overviews_dict['list_OPI'].keys()):
+        if (opi in overviews_dict['list_OPI'].keys()):
             # OPI déja traitée
-            cliche_already_calculated.append(cliche)
+            opi_already_calculated.append(opi)
         else:
             print('  image :', filename)
             color = [randrange(255), randrange(255), randrange(255)]
@@ -318,7 +318,7 @@ def main():
                 mtd[color[0]] = {}
             if color[1] not in mtd[color[0]]:
                 mtd[color[0]][color[1]] = {}
-            mtd[color[0]][color[1]][color[2]] = cliche
+            mtd[color[0]][color[1]][color[2]] = opi
  
             tilebox_image = get_tilebox(filename, overviews_init)
 
@@ -333,7 +333,7 @@ def main():
             args_cut_image.append(argument_zyx)  
 
             # on ajout l'OPI traitée a la liste (avec sa couleur)
-            overviews_dict["list_OPI"][cliche] = color
+            overviews_dict["list_OPI"][opi] = color
     
     print(" Découpage" )
 
@@ -397,9 +397,9 @@ def main():
     with open(args.cache+'/overviews.json', 'w') as outfile:
         json.dump(overviews_dict, outfile)
 
-    print("\n", len(list_filename) - len(cliche_already_calculated),"/",len(list_filename),"OPI(s) ajoutée(s)")
-    if len(cliche_already_calculated) > 0:
-        print(cliche_already_calculated, "déjà traitées : OPI non recalculée(s)")
+    print("\n", len(list_filename) - len(opi_already_calculated),"/",len(list_filename),"OPI(s) ajoutée(s)")
+    if len(opi_already_calculated) > 0:
+        print(opi_already_calculated, "déjà traitées : OPI non recalculée(s)")
 
 if __name__ == "__main__":
     main()

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -34,13 +34,13 @@ nb_bands = 3
 PNG_DRIVER = gdal.GetDriverByName('png')
 
 
-def cut_opi_1tile(filename, tile_dir, image_name, origin, tileSize, tile, out_raster_srs, nb_bands):
+def cut_opi_1tile(filename, tile_dir, image_name, origin, tile_size, tile, out_raster_srs, nb_bands):
     """Cut and reseample a specified image at a given level"""
     if verbose > 0:
         print("~~~cut_opi_1tile")
 
     input_image = gdal.Open(filename)
-    target_ds = gdal.GetDriverByName('MEM').Create('', tileSize['width'], tileSize['height'], nb_bands, gdal.GDT_Byte)
+    target_ds = gdal.GetDriverByName('MEM').Create('', tile_size['width'], tile_size['height'], nb_bands, gdal.GDT_Byte)
     target_ds.SetGeoTransform((origin['x'], tile['resolution'], 0, origin['y'], 0, -tile['resolution']))
     target_ds.SetProjection(out_raster_srs)
     target_ds.FlushCache()

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -11,13 +11,10 @@ import gdal
 import argparse
 from collections import defaultdict
 
-os.environ['PROJ_LIB'] = 'C:\\Users\\ftoromanoff\\AppData\\Local\\Programs\\Python\\Python37-32\\Lib\\site-packages\\osgeo\\data\\proj'
+# os.environ['PROJ_LIB'] = 'C:\\Users\\ftoromanoff\\AppData\\Local\\Programs\\Python\\Python37-32\\Lib\\site-packages\\osgeo\\data\\proj'
 
 import multiprocessing
 cpu_dispo = multiprocessing.cpu_count()
-
-# scripts\createCache.py -i D:\PackO\Donnees\OPI_Test\*.tif -c cache_new
-# scripts\createCache.py -i Z:\PackO\mini_selectOPI_hardlink\*.tif -c Z:\PackO\minicache_camV2_56_Multi_
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--cache", help="cache directory (default: cache)", type=str, default="cache")

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 """This script create or update a cache from a list of OPI"""
 import os
 import math
@@ -196,7 +198,7 @@ def create_ortho_and_graph_1arg(arguments):
     advancement = arguments['advancement']
 
     if advancement != 0:
-        print("  ",advancement,"% terminé")
+        print("█", end='', flush=True)
 
     tile_x = tile['x']
     tile_y = tile['y']
@@ -376,18 +378,21 @@ def main():
     print(" ", nb_tiles, "tuiles à traiter")
 
     counter = 0
+    nb_steps = 20
     for i in range(nb_tiles):
         args_create_ortho_and_graph[i]['advancement'] = 0
-        if ( math.floor(i%(nb_tiles * 0.1)) == 0 ):
+        if ( math.floor(i%(nb_tiles / nb_steps )) == 0 ):
             counter = counter + 1
-            args_create_ortho_and_graph[i]['advancement'] = counter * 10
-
+            args_create_ortho_and_graph[i]['advancement'] = counter * nb_steps
+    
+    print('|', end='', flush=True)
     POOL = multiprocessing.Pool(cpu_dispo-1)
     POOL.map(create_ortho_and_graph_1arg, args_create_ortho_and_graph)
 
     POOL.close()
     POOL.join()
 
+    print('|')
     print('=> DONE')
 
     #Finitions

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -36,14 +36,14 @@ nb_bands = 3
 
 PNG_DRIVER = gdal.GetDriverByName('png')
 
-def cut_opi_1tile(filename, tile_dir, image_name, origin, tileSize, tile, out_raster_srs, nb_canaux):
+def cut_opi_1tile(filename, tile_dir, image_name, origin, tileSize, tile, out_raster_srs, nb_bands):
     """Cut and reseample a specified image at a given level"""
     if verbose > 0:
         print("~~~cut_opi_1tile")
 
     input_image = gdal.Open(filename)
     
-    target_ds = gdal.GetDriverByName('MEM').Create('', tileSize['width'], tileSize['height'], nb_canaux, gdal.GDT_Byte)
+    target_ds = gdal.GetDriverByName('MEM').Create('', tileSize['width'], tileSize['height'], nb_bands, gdal.GDT_Byte)
     target_ds.SetGeoTransform((origin['x'], tile['resolution'], 0, origin['y'], 0, -tile['resolution']))
     target_ds.SetProjection(out_raster_srs)
     target_ds.FlushCache()
@@ -59,13 +59,13 @@ def cut_opi_1tile(filename, tile_dir, image_name, origin, tileSize, tile, out_ra
 
     return
 
-def create_blank_tile(overviews, tile, nb_canaux, out_srs):
+def create_blank_tile(overviews, tile, nb_bands, out_srs):
     """Return a blank georef image for a tile."""
     origin_x = overviews['crs']['boundingBox']['xmin'] + tile['x'] * tile['resolution'] * overviews['tileSize']['width']
     origin_y = overviews['crs']['boundingBox']['ymax'] - tile['y'] * tile['resolution'] * overviews['tileSize']['height']
     target_ds = gdal.GetDriverByName('MEM').Create('',
                                                    overviews['tileSize']['width'], overviews['tileSize']['height'],
-                                                   nb_canaux, gdal.GDT_Byte)
+                                                   nb_bands, gdal.GDT_Byte)
     target_ds.SetGeoTransform((origin_x, tile['resolution'], 0,
                                origin_y, 0, -tile['resolution']))
     target_ds.SetProjection(out_srs)
@@ -373,7 +373,7 @@ def main():
 
     print(" Calcul")
     nb_tiles = len(args_create_ortho_and_graph)
-    print(" ", nb_tiles, "tuiles a traitées")
+    print(" ", nb_tiles, "tuiles à traiter")
 
     counter = 0
     for i in range(nb_tiles):

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -11,7 +11,13 @@ import gdal
 import argparse
 from collections import defaultdict
 
-from threading import Thread
+os.environ['PROJ_LIB'] = 'C:\\Users\\ftoromanoff\\AppData\\Local\\Programs\\Python\\Python37-32\\Lib\\site-packages\\osgeo\\data\\proj'
+
+import multiprocessing
+cpu_dispo = multiprocessing.cpu_count()
+
+# scripts\createCache.py -i D:\PackO\Donnees\OPI_Test\*.tif -c cache_new
+# scripts\createCache.py -i Z:\PackO\mini_selectOPI_hardlink\*.tif -c Z:\PackO\minicache_camV2_56_Multi_
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--cache", help="cache directory (default: cache)", type=str, default="cache")
@@ -33,34 +39,27 @@ port = os.getenv('PGPORT', default='5432')
 
 PNG_DRIVER = gdal.GetDriverByName('png')
 
+def Cut_OPI(filename, tile_dir, image_name, origin, tileSize, tile, out_raster_srs):
 
-class Cut_OPI(Thread):
+    input_image = gdal.Open(filename)
+    
+    target_ds = gdal.GetDriverByName('MEM').Create('', tileSize, tileSize, 3, gdal.GDT_Byte)
+    target_ds.SetGeoTransform((origin['x'], tile['resolution'], 0, origin['y'], 0, -tile['resolution']))
+    target_ds.SetProjection(out_raster_srs)
+    target_ds.FlushCache()
+    opi = target_ds
 
-    def __init__(self, input_image, tile_dir, image_name, overviews, tile, out_raster_srs):
-        Thread.__init__(self)
-        self.input_image = input_image
-        self.tile_dir = tile_dir
-        self.image_name = image_name
-        self.overviews = overviews
-        self.tile = tile
-        self.out_raster_srs = out_raster_srs
+    # on reech l'OPI dans cette image
+    gdal.Warp(opi, input_image)
 
-        # on cree une image 3 canaux pour la tuile
-        #self.opi = create_blank_tile(self.overviews, self.tile, 3, self.out_raster_srs)
+    # on export en png (todo: gerer le niveau de Q)
+    dst_ds = PNG_DRIVER.CreateCopy(tile_dir +"/"+ image_name +".png", opi)
+    opi = None
+    dst_ds = None
 
+    return
 
-    def run(self):
-        # on cree une image 3 canaux pour la tuile
-        self.opi = create_blank_tile(self.overviews, self.tile, 3, self.out_raster_srs)
-        # on reech l'OPI dans cette image
-        gdal.Warp(self.opi, self.input_image)
-        # on export en jpeg (todo: gerer le niveau de Q)
-        PNG_DRIVER.CreateCopy( self.tile_dir +"/"+ self.image_name +".png", self.opi)
-
-
-
-
-def create_blank_tile(overviews, tile, nb_canaux, out_raster_srs):
+def create_blank_tile(overviews, tile, nb_canaux, out_srs):
     """Return a blank georef image for a tile."""
     origin_x = overviews['crs']['boundingBox']['xmin'] + tile['x'] * tile['resolution'] * overviews['tileSize']['width']
     origin_y = overviews['crs']['boundingBox']['ymax'] - tile['y'] * tile['resolution'] * overviews['tileSize']['height']
@@ -69,11 +68,11 @@ def create_blank_tile(overviews, tile, nb_canaux, out_raster_srs):
                                                    nb_canaux, gdal.GDT_Byte)
     target_ds.SetGeoTransform((origin_x, tile['resolution'], 0,
                                origin_y, 0, -tile['resolution']))
-    target_ds.SetProjection(out_raster_srs.ExportToWkt())
+    target_ds.SetProjection(out_srs)
     target_ds.FlushCache()
     return target_ds
 
-def get_tile_limits( filename):
+def get_tile_limits(filename):
     """Return tms limits for a georef image at a given level"""
     if verbose > 0:
         print("~~~get_tile_limits:", end='')
@@ -94,16 +93,12 @@ def get_tile_limits( filename):
         print(" DONE")
     return tile_limits
 
-def cut_image(input_filename, out_raster_srs, overviews, thread_list):
-    """Update the cache for an input OPI: cut"""
+
+def getTileBox(input_filename, overviews):
     if verbose > 0:
-        print("~~~cut_image")
-    input_image = gdal.Open(input_filename)
-    stem = Path(input_filename).stem
-    if not("dataSet" in overviews):
-        overviews['dataSet'] = {}
-        overviews['dataSet']['boundingBox'] = {}
-        overviews['dataSet']['limits'] = {}
+        print("~~~getTileBox")
+
+    tileBox = {}
 
     tile_limits = get_tile_limits(input_filename)
 
@@ -119,29 +114,29 @@ def cut_image(input_filename, out_raster_srs, overviews, thread_list):
         if tile_limits['UpperCorner'][1] > overviews['dataSet']['boundingBox']['UpperCorner'][1]:
             overviews['dataSet']['boundingBox']['UpperCorner'][1] = tile_limits['UpperCorner'][1]
 
-    # for z in tiles:
     for tile_z in range(overviews['level']['min'], overviews['level']['max'] + 1):
-        print('  zoom :', tile_z)
-
         resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - tile_z)
 
-        MinTileCol = \
-            math.floor(round((tile_limits['LowerCorner'][0] - overviews['crs']['boundingBox']['xmin'])/(resolution*overviews['tileSize']['width']),8))
-        MinTileRow = \
-            math.floor(round((overviews['crs']['boundingBox']['ymax']-tile_limits['UpperCorner'][1])/(resolution*overviews['tileSize']['height']),8))
-        MaxTileCol = \
-            math.ceil(round((tile_limits['UpperCorner'][0] - overviews['crs']['boundingBox']['xmin'])/(resolution*overviews['tileSize']['width']),8)) - 1
-        MaxTileRow = \
-            math.ceil(round((overviews['crs']['boundingBox']['ymax']-tile_limits['LowerCorner'][1])/(resolution*overviews['tileSize']['height']),8)) - 1
+        MinTileCol = math.floor(round((tile_limits['LowerCorner'][0] - overviews['crs']['boundingBox']['xmin'])/(resolution*overviews['tileSize']['width']),8))
+        MinTileRow = math.floor(round((overviews['crs']['boundingBox']['ymax']-tile_limits['UpperCorner'][1])/(resolution*overviews['tileSize']['height']),8))
+        MaxTileCol = math.ceil(round((tile_limits['UpperCorner'][0] - overviews['crs']['boundingBox']['xmin'])/(resolution*overviews['tileSize']['width']),8)) - 1
+        MaxTileRow =  math.ceil(round((overviews['crs']['boundingBox']['ymax']-tile_limits['LowerCorner'][1])/(resolution*overviews['tileSize']['height']),8)) - 1
+
+        tileBox_z = {
+            'MinTileCol': MinTileCol,
+            'MinTileRow': MinTileRow,
+            'MaxTileCol': MaxTileCol,
+            'MaxTileRow': MaxTileRow
+        }
+        tileBox[str(tile_z)] = tileBox_z
 
         if not( str(tile_z) in overviews['dataSet']['limits'] ):
             overviews['dataSet']['limits'][str(tile_z)] = {
                 'MinTileCol': MinTileCol,
                 'MinTileRow': MinTileRow,
                 'MaxTileCol': MaxTileCol,
-                'MaxTileRow': MaxTileRow,
+                'MaxTileRow': MaxTileRow
             }
-
         else:
             if MinTileCol < overviews['dataSet']['limits'][str(tile_z)]['MinTileCol']:
                 overviews['dataSet']['limits'][str(tile_z)]['MinTileCol'] = MinTileCol
@@ -152,19 +147,81 @@ def cut_image(input_filename, out_raster_srs, overviews, thread_list):
             if MaxTileRow > overviews['dataSet']['limits'][str(tile_z)]['MaxTileRow']:
                 overviews['dataSet']['limits'][str(tile_z)]['MaxTileRow'] = MaxTileRow
 
+    return tileBox
+
+def cut_image(input_filename, out_srs, overviews, tileBox):
+    """Update the cache for an input OPI: cut"""
+    if verbose > 0:
+        print("~~~cut_image")
+    #input_image = gdal.Open(input_filename)
+    stem = Path(input_filename).stem
+ 
+    # for z in tiles:
+    for tile_z in range(overviews['level']['min'], overviews['level']['max'] + 1):
+        print('  zoom :', tile_z)
+
+        resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - tile_z)
+
+        MinTileCol = tileBox[str(tile_z)]['MinTileCol']
+        MaxTileCol = tileBox[str(tile_z)]['MaxTileCol']
+        MinTileRow = tileBox[str(tile_z)]['MinTileRow']
+        MaxTileRow = tileBox[str(tile_z)]['MaxTileRow']
+
+
         for tile_x in range(MinTileCol, MaxTileCol + 1):    
             for tile_y in range(MinTileRow, MaxTileRow + 1):
+                origin = {
+                    'x': overviews['crs']['boundingBox']['xmin'] + tile_x * resolution * overviews['tileSize']['width'],
+                    'y': overviews['crs']['boundingBox']['ymax'] - tile_y * resolution * overviews['tileSize']['height']
+                }
 
                 tile_dir = args.cache+'/'+str(tile_z)+'/'+str(tile_y)+'/'+str(tile_x)
+                tile = {'x': tile_x, 'y': tile_y, 'resolution': resolution}
+
                 # si necessaire on cree le dossier de la tuile             
                 Path(tile_dir).mkdir(parents=True, exist_ok=True)
 
-                thread_list.append(Cut_OPI(input_image, tile_dir, stem, overviews, {'x': tile_x, 'y': tile_y, 'resolution': resolution}, out_raster_srs))
-                #thread_list[len(thread_list)-1].start()
+
+                Cut_OPI_p(input_filename, tile_dir, stem, origin, 256, tile, out_srs)
 
 
+def cut_image_1arg(arguments):
+    """Update the cache for an input OPI: cut"""
+    if verbose > 0:
+        print("~~~cut_image")
 
+    filename = arguments['filename']
+    out_srs = arguments['out_srs']
+    overviews = arguments['overviews']
+    tileBox = arguments['tileBox']
 
+    stem = Path(filename).stem
+ 
+    # for z in tiles:
+    for tile_z in range(overviews['level']['min'], overviews['level']['max'] + 1):
+        print('  (',stem,') level :', tile_z)
+
+        resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - tile_z)
+
+        MinTileCol = tileBox[str(tile_z)]['MinTileCol']
+        MaxTileCol = tileBox[str(tile_z)]['MaxTileCol']
+        MinTileRow = tileBox[str(tile_z)]['MinTileRow']
+        MaxTileRow = tileBox[str(tile_z)]['MaxTileRow']
+
+        for tile_x in range(MinTileCol, MaxTileCol + 1):    
+            for tile_y in range(MinTileRow, MaxTileRow + 1):
+                origin = {
+                    'x': overviews['crs']['boundingBox']['xmin'] + tile_x * resolution * overviews['tileSize']['width'],
+                    'y': overviews['crs']['boundingBox']['ymax'] - tile_y * resolution * overviews['tileSize']['height']
+                }
+
+                tile_dir = args.cache+'/'+str(tile_z)+'/'+str(tile_y)+'/'+str(tile_x)
+                tile = {'x': tile_x, 'y': tile_y, 'resolution': resolution}
+
+                # si necessaire on cree le dossier de la tuile             
+                Path(tile_dir).mkdir(parents=True, exist_ok=True)
+
+                Cut_OPI(filename, tile_dir, stem, origin, 256, tile, out_srs)
 
 def create_ortho_and_graph(tile, overviews, db_graph, out_raster_srs):
     """Update the cache for an input OPI: create ortho and graph"""
@@ -184,6 +241,9 @@ def create_ortho_and_graph(tile, overviews, db_graph, out_raster_srs):
 
     tile_dir = args.cache+'/'+str(tile_z)+'/'+str(tile_y)+'/'+str(tile_x)
     list_filename = glob.glob(tile_dir+'/*.png')
+
+    ecriture = False
+
     for filename in list_filename:
         stem = Path(filename).stem
 
@@ -198,6 +258,8 @@ def create_ortho_and_graph(tile, overviews, db_graph, out_raster_srs):
         # si le mask est vide, on a termine
         val_max = np.amax(img_mask)
         if val_max > 0:
+
+            ecriture = True
 
             opi = gdal.Open(filename)
 
@@ -215,13 +277,94 @@ def create_ortho_and_graph(tile, overviews, db_graph, out_raster_srs):
                 graph_i[(img_mask != 0)] = color[i]
                 graph.GetRasterBand(i+1).WriteArray(graph_i)
 
-            PNG_DRIVER.CreateCopy(tile_dir+"/ortho.png", ortho)
-            PNG_DRIVER.CreateCopy(tile_dir+"/graph.png", graph)
+    if ecriture:
+        dst_ortho = PNG_DRIVER.CreateCopy(tile_dir+"/ortho.png", ortho)
+        dst_graph = PNG_DRIVER.CreateCopy(tile_dir+"/graph.png", graph)
+        dst_ortho = None
+        dst_graph = None
+
+    ortho = None
+    graph = None
+
+def create_ortho_and_graph_1arg(arguments):
+    """Update the cache for an input OPI: create ortho and graph"""
+    if verbose > 0:
+        print("~~~create_ortho_and_graph_1arg")
+
+    tile = arguments['tile']
+    overviews = arguments['overviews']
+    conn_string = arguments['conn_string']
+    out_srs = arguments['out_srs']
+
+    # besoin : tile_z, tile_x, tile_y
+    tile_x = tile['x']
+    tile_y = tile['y']
+    tile_z = tile['z']
+
+    print("*",end='')
+    #print("  level :", str(tile_z), "- tuile", tile_x, tile_y)
+
+    resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - tile_z)
+
+    # on cree le graphe et l'ortho
+    ortho = create_blank_tile(overviews, {'x': tile_x, 'y': tile_y, 'resolution': resolution}, 3, out_srs)
+    graph = create_blank_tile(overviews, {'x': tile_x, 'y': tile_y, 'resolution': resolution}, 3, out_srs)
+
+    tile_dir = args.cache+'/'+str(tile_z)+'/'+str(tile_y)+'/'+str(tile_x)
+    list_filename = glob.glob(tile_dir+'/*.png')
+
+    ecriture = False
+
+    for filename in list_filename:
+        stem = Path(filename).stem
+
+        color = overviews["list_OPI"][stem]
+        
+        # on cree une image mono canal pour la tuile
+        mask = create_blank_tile(overviews, {'x': tile_x, 'y': tile_y, 'resolution': resolution}, 3, out_srs)
+
+        # on rasterise la partie du graphe qui concerne ce cliche
+        db_graph = gdal.OpenEx(conn_string, gdal.OF_VECTOR)
+        gdal.Rasterize(mask, db_graph, SQLStatement='select geom from ' + args.table + ' where cliche = \''+stem+'\' ')
+        img_mask = mask.GetRasterBand(1).ReadAsArray()
+        # si le mask est vide, on a termine
+        val_max = np.amax(img_mask)
+        if val_max > 0:
+
+            ecriture = True
+
+            opi = gdal.Open(filename)
+
+            for i in range(3):
+                opi_i = opi.GetRasterBand(i+1).ReadAsArray()
+                opi_i[(img_mask == 0)] = 0
+
+                ortho_i = ortho.GetRasterBand(i+1).ReadAsArray()
+
+                ortho_i[(img_mask != 0)] = 0
+                ortho.GetRasterBand(i+1).WriteArray(np.add(opi_i, ortho_i))
+
+                graph_i = graph.GetRasterBand(i+1).ReadAsArray()
+
+                graph_i[(img_mask != 0)] = color[i]
+                graph.GetRasterBand(i+1).WriteArray(graph_i)
+
+    if ecriture:
+        dst_ortho = PNG_DRIVER.CreateCopy(tile_dir+"/ortho.png", ortho)
+        dst_graph = PNG_DRIVER.CreateCopy(tile_dir+"/graph.png", graph)
+        dst_ortho = None
+        dst_graph = None
+
+    ortho = None
+    graph = None
          
 def main():
     """Create or Update the cache for list of input OPI."""
     import shutil
     import json
+
+    if os.path.isdir(args.input):
+        args.input = args.input + '\*.tif'
 
     if not os.path.isdir(args.cache):
         # creation dossier cache
@@ -232,16 +375,22 @@ def main():
         shutil.copy2(args.overviews, args.cache+'/overviews.json')
 
     with open(args.cache+'/overviews.json') as json_overviews:
-        overviews_dict = json.load(json_overviews)
+        overviews_init = json.load(json_overviews)
+        overviews_dict = overviews_init
     if not ("list_OPI" in overviews_dict):
         overviews_dict["list_OPI"] = {}
 
-    out_raster_srs = gdal.osr.SpatialReference()
-    out_raster_srs.ImportFromEPSG(overviews_dict['crs']['code'])
-    conn_string = "PG:host="+host+" dbname="+database+" user="+user+" password="+password
+    if not("dataSet" in overviews_dict):
+        overviews_dict['dataSet'] = {}
+        overviews_dict['dataSet']['boundingBox'] = {}
+        overviews_dict['dataSet']['limits'] = {}
 
-    if os.path.isdir(args.input):
-        args.input = args.input + '\*.tif'
+
+    out_raster_srs = gdal.osr.SpatialReference()
+    out_raster_srs.ImportFromEPSG(overviews_init['crs']['code'])
+    out_srs = out_raster_srs.ExportToWkt()
+
+    conn_string = "PG:host="+host+" dbname="+database+" user="+user+" password="+password
 
     list_filename = glob.glob(args.input)
     if verbose > 0:
@@ -254,10 +403,11 @@ def main():
         mtd = {}
 
     cliche_dejaTraites = []
-    thread_list = []
 
-    # Decoupage des images
-    print("Decoupe des images :")
+    argument4process = []
+    # Decoupage des images et calcul de l'emprise globale
+    print("Découpe des images :")
+    print(" Préparation")
     for filename in list_filename:
         cliche = Path(filename).stem
      
@@ -265,7 +415,7 @@ def main():
             # OPI déja traitée
             cliche_dejaTraites.append(cliche)
         else:
-            print(' image :', filename)
+            print('  image :', filename)
             color = [randrange(255), randrange(255), randrange(255)]
             while (color[0] in mtd) and (color[1] in mtd[color[0]]) and (color[2] in mtd[color[0]][color[1]]):
                 color = [randrange(255), randrange(255), randrange(255)]
@@ -274,47 +424,68 @@ def main():
             if color[1] not in mtd[color[0]]:
                 mtd[color[0]][color[1]] = {}
             mtd[color[0]][color[1]][color[2]] = cliche
-            cut_image(filename, out_raster_srs, overviews_dict, thread_list)
-            # process_image(overviews_dict, db_graph, filename, color, out_raster_srs)
+ 
+            tileBox_Image = getTileBox(filename, overviews_init)
+
+            argument_zyx = {
+                'filename': filename,
+                'out_srs': out_srs,
+                'overviews': overviews_init,
+                'tileBox': tileBox_Image
+            }
+
+            argument4process.append(argument_zyx)  
+
             # on ajout l'OPI traitée a la liste (avec sa couleur)
             overviews_dict["list_OPI"][cliche] = color
     
-    #for i in range(len(thread_list)):
-    #    thread_list[i].start()
+    print(" Découpage" )
 
-    for i in range(3):
-        thread_list[i].start()
-        #input('Press <ENTER> to continue')
+    POOL = multiprocessing.Pool(cpu_dispo-1)
+    POOL.map(cut_image_1arg, argument4process)
 
-    for i in range(11):
-        thread_list[i].join()
+    POOL.close()
+    POOL.join()
 
-
-    print(len(thread_list))
-    input('END of Cut Press <ENTER> to continue')
-
-    print("Création du graph et de l'ortho (par tuile) :")
+    print('=> DONE')
+    
+    print("Génération du graph et de l'ortho (par tuile) :")
     db_graph = gdal.OpenEx(conn_string, gdal.OF_VECTOR)
     if db_graph is None:
         raise ValueError("Connection to database failed")
+
+    argument4process = []
+
+    print(" Préparation")
+    
     # Calcul des ortho et graph
-
     for level in overviews_dict["dataSet"]["limits"]:
-
-        print(" level :", level)
+        print("  level :", level)
 
         level_limits = overviews_dict["dataSet"]["limits"][level]
 
         for tile_x in range(level_limits["MinTileCol"], level_limits["MaxTileCol"] + 1):    
             for tile_y in range(level_limits["MinTileRow"], level_limits["MaxTileRow"] + 1):
 
-                print("  tuile :", tile_x, tile_y)
+                argument_zyx = {
+                    'tile': {'x': tile_x, 'y': tile_y, 'z': int(level)},
+                    'overviews': overviews_dict,
+                    'conn_string': conn_string,
+                    'out_srs': out_srs
+                }
+                argument4process.append(argument_zyx)
 
-                create_ortho_and_graph({'x': tile_x, 'y': tile_y, 'z': int(level)}, overviews_dict, db_graph, out_raster_srs)
-                # create_ortho_and_graph(overviews_dict, db_graph, filename, color, out_raster_srs)
+    print(" Calcul")
+    POOL = multiprocessing.Pool(cpu_dispo-1)
 
+    POOL.map(create_ortho_and_graph_1arg, argument4process)
 
+    POOL.close()
+    POOL.join()
 
+    print('\n=> DONE')
+
+    #Finitions
     with open(args.cache+'/cache_mtd.json', 'w') as outfile:
         json.dump(mtd, outfile)
 

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -196,7 +196,7 @@ def create_ortho_and_graph_1arg(arguments):
     advancement = arguments['advancement']
 
     if advancement != 0:
-        print("  ",advancement,"% terminée")
+        print("  ",advancement,"% terminé")
 
     tile_x = tile['x']
     tile_y = tile['y']

--- a/scripts/createCache.py
+++ b/scripts/createCache.py
@@ -266,6 +266,12 @@ def main():
         # creation dossier cache
         os.mkdir(args.cache)
 
+    if os.path.exists(args.cache + '/cache_mtd.json'):
+        with open(args.cache + '/cache_mtd.json', 'r') as inputfile:
+            mtd = json.load(inputfile)
+    else:
+        mtd = {}
+
     if not os.path.exists(args.cache + '/overviews.json'):
         # creation fichier overviews.json a partir d'un fichier ressource
         shutil.copy2(args.overviews, args.cache + '/overviews.json')
@@ -290,12 +296,6 @@ def main():
     list_filename = glob.glob(args.input)
     if verbose > 0:
         print(len(list_filename), "fichier(s) a traiter")
-
-    try:
-        with open(args.cache + '/cache_mtd.json', 'r') as inputfile:
-            mtd = json.load(inputfile)
-    except ValueError:
-        mtd = {}
 
     opi_already_calculated = []
 


### PR DESCRIPTION
Modification du script python de création du cache.

- Séparation du process en 2 étapes distinctes : 
   - Découpage en tuile, image par image
   - Génération de l'ortho et du graph, tuile par tuile

- Chacune des étapes est ensuite multiprocessée en utilisant le max des CPU disponible - 1

Sur mon PC, le calcul du cache sur 31 OPI a pris 1h05 en utilisant 7 CPU contre 2h45 dans la version précédente