### PR TITLE
version multithread de l'application des patchs (v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "serveur.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "nyc --reporter=text mocha --cache cache_test",
-    "test-coveralls": "nyc --reporter=lcov --report-dir=coverage mocha --cache cache_test"
+    "test": "c8 -r text mocha --cache cache_test",
+    "test-coveralls": "c8 -r lcov --report-dir=coverage mocha --cache cache_test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/gmaillet/ign-api-mosaique#readme",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "c8": "^7.3.5",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "chai-json-schema": "^1.5.1",
@@ -29,20 +30,20 @@
     "express-validator": "^6.5.0",
     "fs": "0.0.1-security",
     "geojson-validation": "^1.0.2",
+    "git-describe": "^4.0.4",
     "jimp": "^0.14.0",
     "mocha": "^8.1.1",
     "nocache": "^2.1.0",
-    "nyc": "^15.1.0",
     "proj4": "^2.6.2",
     "pureimage": "^0.2.1",
     "supervisor": "^0.12.0",
     "swagger-editor-dist": "^3.10.0",
     "swagger-ui-dist": "^3.25.5",
     "swagger-ui-express": "^4.1.4",
+    "workerpool": "^6.0.3",
     "xml2js": "^0.4.23",
     "yamljs": "^0.3.0",
-    "yargs": "^15.4.1",
-    "git-describe": "^4.0.4"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "eslint": "^7.2.0",

--- a/serveur.js
+++ b/serveur.js
@@ -10,6 +10,7 @@ const debugServer = require('debug')('serveur');
 const debug = require('debug');
 const path = require('path');
 const nocache = require('nocache');
+const workerpool = require('workerpool');
 
 const { argv } = require('yargs')
   .version(false)
@@ -106,6 +107,11 @@ try {
   app.use('/doc', swaggerUi.serve, swaggerUi.setup(global.swaggerDocument, options));
   global.swaggerDocument.info.version = '???';
   global.swaggerDocument.servers[0].url = app.urlApi;
+  global.minJobForWorkers = 20;
+
+  // Creation d'un pool de workers pour traiter les calculs lourds (patchs)
+  // par defaut, autant de workers que de coeurs sur la machine
+  app.workerpool = workerpool.pool();
 
   app.use('/', wmts);
   app.use('/', graph);
@@ -116,6 +122,7 @@ try {
   module.exports = app.listen(PORT, () => {
     debug.log(`URL de l'api : ${app.urlApi} \nURL de la documentation swagger : ${app.urlApi}/doc`);
   });
+  module.exports.workerpool = app.workerpool;
 } catch (err) {
   debug.log(err);
 }

--- a/test/file.js
+++ b/test/file.js
@@ -7,6 +7,7 @@ const server = require('..');
 
 describe('Files', () => {
   after((done) => {
+    server.workerpool.terminate();
     server.close();
     done();
   });

--- a/test/graph.js
+++ b/test/graph.js
@@ -26,6 +26,7 @@ const schema = {
 
 describe('Graph', () => {
   after((done) => {
+    server.workerpool.terminate();
     server.close();
     done();
   });

--- a/test/misc.js
+++ b/test/misc.js
@@ -7,6 +7,7 @@ const server = require('..');
 
 describe('Miscellanous', () => {
   after((done) => {
+    server.workerpool.terminate();
     server.close();
     done();
   });

--- a/test/patch.js
+++ b/test/patch.js
@@ -8,6 +8,7 @@ const server = require('..');
 
 describe('Patch', () => {
   after((done) => {
+    server.workerpool.terminate();
     server.close();
     done();
   });

--- a/test/wmts.js
+++ b/test/wmts.js
@@ -7,6 +7,7 @@ const server = require('..');
 
 describe('Wmts', () => {
   after((done) => {
+    server.workerpool.terminate();
     server.close();
     done();
   });


### PR DESCRIPTION
Nouvelle PR en remplacement de #53

# Objectif
accélérer le traitement des gros patchs. Actuellement, sur avec des OPI CamV2, l'application d'un patch couvrant 1/3 de la surface utile d'une OPI prend 4 min sur ma machine. 

# Principe
On crée un pool de workers au niveau du serveur avec le nombre de threads par défaut (nb de coeurs de la machine -1). 
Il y a une variable globale (minJobForWorkers) qui permet de régler le nombre minimale de traitements avant d'enclencher l'utilisation des workers (pour éviter de pénaliser les petits patchs).
La parallélisation se fait à la fois au niveau de la préparation des patchs (lorsqu'on crée le masque et que l'on vérifie si on ne sort pas de la zone) et au niveau de l'application des patchs.

# Autre modification
Il a été nécessaire de remplacer le module nyc par c8 dans les tests pour l'estimation de la couverture de test. En effet, nyc n'est pas compatible avec les workers.

# Résultat
L'application d'un patch couvrant 1/3 de la surface utile d'une OPI prend 1 min sur ma machine (au lieu de 4 min), sans perte de performance sur les petits patchs.