### PR TITLE
Fix confusion lvlMax dataset/overviews et erreur dans la valeur de résolution

### DIFF
--- a/routes/graph.js
+++ b/routes/graph.js
@@ -29,10 +29,10 @@ router.get('/graph', [
 
   const xOrigin = overviews.crs.boundingBox.xmin;
   const yOrigin = overviews.crs.boundingBox.ymax;
-  const Rmax = overviews.resolution;
-  const datasetMaxLvl = overviews.dataSet.level.max;
+  // const Rmax = overviews.resolution;
+  const lvlMax = overviews.dataSet.level.max;
 
-  const resol = Rmax * 2 ** (overviews.level.max - datasetMaxLvl);
+  const resol = overviews.resolution * 2 ** (overviews.level.max - lvlMax);
 
   // il faut trouver la tuile
   const Px = (x - xOrigin) / resol;
@@ -42,7 +42,7 @@ router.get('/graph', [
   const I = Math.floor(Px - Tx * overviews.tileSize.width);
   const J = Math.floor(Py - Ty * overviews.tileSize.height);
 
-  const url = path.join(global.dir_cache, `${datasetMaxLvl}`, `${Ty}`, `${Tx}`, 'graph.png');
+  const url = path.join(global.dir_cache, `${lvlMax}`, `${Ty}`, `${Tx}`, 'graph.png');
   debug(url);
   if (!fs.existsSync(url)) {
     res.status(201).send('{"color":[0,0,0], "cliche":"out of bounds"}');

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -74,14 +74,14 @@ function getTiles(features, overviews) {
   const lvlMax = overviews.dataSet.level.max;
   const xOrigin = overviews.crs.boundingBox.xmin;
   const yOrigin = overviews.crs.boundingBox.ymax;
-  const Rmax = overviews.resolution;
+  // const Rmax = overviews.resolution;
   const tileWidth = overviews.tileSize.width;
   const tileHeight = overviews.tileSize.height;
 
   // tileSet.forEach((level) => {
   // Array.from({ length: lvlMax - lvlMin + 1 }, (_, i) => i + lvlMin).forEach((level) => {
   for (let level = lvlMin; level <= lvlMax; level += 1) {
-    const resolution = Rmax * 2 ** (lvlMax - level);
+    const resolution = overviews.resolution * 2 ** (overviews.level.max - level);
     const x0 = Math.floor((BBox.xmin - xOrigin) / (resolution * tileWidth));
     const x1 = Math.ceil((BBox.xmax - xOrigin) / (resolution * tileWidth));
     const y0 = Math.floor((yOrigin - BBox.ymax) / (resolution * tileHeight));
@@ -105,8 +105,8 @@ function createPatch(tile, geoJson, overviews) {
   debug('createPacth : ', tile);
   const xOrigin = overviews.crs.boundingBox.xmin;
   const yOrigin = overviews.crs.boundingBox.ymax;
-  const Rmax = overviews.resolution;
-  const lvlMax = overviews.level.max;
+  // const Rmax = overviews.resolution;
+  // const lvlMax = overviews.level.max;
   const tileWidth = overviews.tileSize.width;
   const tileHeight = overviews.tileSize.height;
 
@@ -121,7 +121,7 @@ function createPatch(tile, geoJson, overviews) {
     ctx.beginPath();
     let first = true;
     /* eslint-disable no-restricted-syntax */
-    const resolution = Rmax * 2 ** (lvlMax - tile.z);
+    const resolution = overviews.resolution * 2 ** (overviews.level.max - tile.z);
     for (const point of feature.geometry.coordinates[0]) {
       const i = Math.round((point[0] - xOrigin - tile.x * tileWidth * resolution)
             / resolution);

--- a/routes/wmts.js
+++ b/routes/wmts.js
@@ -96,12 +96,12 @@ router.get('/wmts', [
     const tileMatrix = [];
     const tileMatrixLimit = [];
 
-    const resLevelMax = overviews.resolution;
+    // const resLevelMax = overviews.resolution;
     const levelMin = overviews.dataSet.level.min;
     const levelMax = overviews.dataSet.level.max;
 
     for (let level = levelMin; level < levelMax + 1; level += 1) {
-      const resolution = resLevelMax * 2 ** (levelMax - level);
+      const resolution = overviews.resolution * 2 ** (overviews.level.max - level);
       const scaleDenominator = resolution / 0.00028;
 
       tileMatrixLimit.push({


### PR DESCRIPTION
Greg hier a fais part d'une confusion dans le level max qui amenait à une erreur dans le calcul de la résolution sur les 3 route de l'API utilisant ce calcul.

Cette branche vise à fixer cette erreur en enlevant les références à un lvlMax de l'overview ainsi qu'a un Rmax (la création de ces variables étant d'ailleurs inutile)