### PR TITLE
[itowns] Visualisation et Sauvegarde des saisies => PR #116 + #117

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -259,6 +259,7 @@ paths:
             type: string
             enum:
               - overviews
+              - activePatchs
 
       responses:
         '200':

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -374,7 +374,7 @@ class Saisie {
 
   clear() {
     if (this.currentStatus === status.WAITING) return;
-    const ok = window.confirm('Voulez-vous effacer toutes les modifications?');
+    const ok = window.confirm('Voulez-vous effacer toutes les modifications ?');
     if (!ok) return;
     console.log('clear');
     this.currentStatus = status.WAITING;
@@ -382,6 +382,29 @@ class Saisie {
     this.message = 'calcul en cours';
 
     fetch(`${this.apiUrl}/patchs/clear?`,
+      {
+        method: 'PUT',
+      }).then((res) => {
+      this.cancelcurrentPolygon();
+      if (res.status === 200) {
+        this.refreshView(['ortho', 'graph']);
+      }
+      res.text().then((msg) => {
+        this.message = msg;
+      });
+    });
+  }
+
+  save() {
+    if (this.currentStatus === status.WAITING) return;
+    const ok = window.confirm('Voulez-vous sauvegarder toutes les modifications ?');
+    if (!ok) return;
+    console.log('save');
+    this.currentStatus = status.WAITING;
+    document.getElementById('viewerDiv').style.cursor = 'wait';
+    this.message = 'calcul en cours';
+
+    fetch(`${this.apiUrl}/patchs/save?`,
       {
         method: 'PUT',
       }).then((res) => {

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -11,11 +11,11 @@ const status = {
   WAITING: 4,
 };
 
-function fetcher(url) {
+export function fetcher(url) {
   return itowns.Fetcher.json(url);
 }
 
-function parser(geojson, option) {
+export function parser(geojson, option) {
   return itowns.GeoJsonParser.parse(geojson, option);
 }
 
@@ -36,11 +36,11 @@ class Saisie {
   async refreshView(layers) {
     // Pour le moment on force le rechargement complet des couches
 
-    let redrawRetouches = false;
+    let redrawPolygons = false;
 
     layers.forEach((id) => {
       this.view.removeLayer(this.layer[id].colorLayer.id);
-      if (id !== 'retouches') {
+      if (id !== 'polygons') {
         this.layer[id].config.opacity = this.layer[id].colorLayer.opacity;
         this.layer[id].colorLayer = new itowns.ColorLayer(
           this.layer[id].name,
@@ -48,26 +48,26 @@ class Saisie {
         );
         this.view.addLayer(this.layer[id].colorLayer);
       } else {
-        redrawRetouches = true;
+        redrawPolygons = true;
       }
     });
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Ortho', 0);
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Opi', 1);
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Graph', 2);
 
-    if (redrawRetouches) {
-      this.layer.retouches.config.opacity = this.layer.retouches.colorLayer.opacity;
+    if (redrawPolygons) {
+      this.layer.polygons.config.opacity = this.layer.polygons.colorLayer.opacity;
 
       const json = await fetcher(`${this.apiUrl}/json/activePatchs`);
       const features = await parser(JSON.stringify(json),
-        this.layer.retouches.optionsGeoJsonParser);
-      this.layer.retouches.config.source = new itowns.FileSource({ features });
-      this.layer.retouches.colorLayer = new itowns.ColorLayer(
-        this.layer.retouches.name,
-        this.layer.retouches.config,
+        this.layer.polygons.optionsGeoJsonParser);
+      this.layer.polygons.config.source = new itowns.FileSource({ features });
+      this.layer.polygons.colorLayer = new itowns.ColorLayer(
+        this.layer.polygons.name,
+        this.layer.polygons.config,
       );
-      this.view.addLayer(this.layer.retouches.colorLayer);
-      itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Retouches', 3);
+      this.view.addLayer(this.layer.polygons.colorLayer);
+      itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Polygons', 3);
     }
 
     this.view.notifyChange();
@@ -155,7 +155,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'polygons']);
       } else {
         this.message = "polygon: out of OPI's bounds";
       }
@@ -376,7 +376,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'polygons']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -398,7 +398,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'polygons']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -421,7 +421,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'polygons']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -444,7 +444,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'polygons']);
       }
       res.text().then((msg) => {
         this.message = msg;

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -146,7 +146,7 @@ async function main() {
       name: 'Polygons',
       config: {
         transparent: true,
-        opacity: 0.62,
+        opacity: opacity.polygons,
       },
       optionsGeoJsonParser: {
         in: {
@@ -168,10 +168,6 @@ async function main() {
 
     layer.polygons.config.source = new itowns.FileSource({ features });
     layer.polygons.config.style = new itowns.Style({
-      fill: {
-        color: 'orange',
-        opacity: 0.5,
-      },
       stroke: {
         color: 'IndianRed',
       },

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -148,6 +148,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   saisie.controllers.undo = menuGlobe.gui.add(saisie, 'undo');
   saisie.controllers.redo = menuGlobe.gui.add(saisie, 'redo');
   saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
+  saisie.controllers.clear = menuGlobe.gui.add(saisie, 'save');
   saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
   saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
 

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* global setupLoadingScreen, GuiTools */
 import * as itowns from 'itowns';
-import Saisie from './Saisie';
+import Saisie, { fetcher, parser } from './Saisie';
 
 // Global itowns pour GuiTools -> peut être améliorer
 global.itowns = itowns;
@@ -13,13 +13,13 @@ console.log('serverAPI:', serverAPI, 'portAPI:', portAPI);
 
 const apiUrl = `http://${serverAPI}:${portAPI}`;
 
-function fetcher(url) {
-  return itowns.Fetcher.json(url);
-}
+// export function fetcher(url) {
+//   return itowns.Fetcher.json(url);
+// }
 
-function parser(geojson, option) {
-  return itowns.GeoJsonParser.parse(geojson, option);
-}
+// function parser(geojson, option) {
+//   return itowns.GeoJsonParser.parse(geojson, option);
+// }
 
 itowns.Fetcher.json(`${apiUrl}/version`)
   .then((obj) => {
@@ -108,7 +108,7 @@ async function main() {
       ortho: 1,
       graph: 0.2,
       opi: 0.5,
-      retouches: 0.75,
+      polygons: 0.75,
     };
 
     const layer = {};
@@ -141,9 +141,9 @@ async function main() {
     itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Graph', 2);
     // Et ouvrir l'onglet "Color Layers" par defaut ?
 
-    // Couche Retouches
-    layer.retouches = {
-      name: 'Retouches',
+    // Couche Polygons
+    layer.polygons = {
+      name: 'Polygons',
       config: {
         transparent: true,
         opacity: 0.62,
@@ -164,10 +164,10 @@ async function main() {
 
     const json = await fetcher(`${apiUrl}/json/activePatchs`);
 
-    const features = await parser(JSON.stringify(json), layer.retouches.optionsGeoJsonParser);
+    const features = await parser(JSON.stringify(json), layer.polygons.optionsGeoJsonParser);
 
-    layer.retouches.config.source = new itowns.FileSource({ features });
-    layer.retouches.config.style = new itowns.Style({
+    layer.polygons.config.source = new itowns.FileSource({ features });
+    layer.polygons.config.style = new itowns.Style({
       fill: {
         color: 'orange',
         opacity: 0.5,
@@ -177,12 +177,12 @@ async function main() {
       },
     });
 
-    layer.retouches.colorLayer = new itowns.ColorLayer(
-      layer.retouches.name,
-      layer.retouches.config,
+    layer.polygons.colorLayer = new itowns.ColorLayer(
+      layer.polygons.name,
+      layer.polygons.config,
     );
-    view.addLayer(layer.retouches.colorLayer);
-    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Retouches', 3);
+    view.addLayer(layer.polygons.colorLayer);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Polygons', 3);
 
     // Request redraw
     console.log('redraw');

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -13,9 +13,18 @@ console.log('serverAPI:', serverAPI, 'portAPI:', portAPI);
 
 const apiUrl = `http://${serverAPI}:${portAPI}`;
 
-itowns.Fetcher.json(`${apiUrl}/version`).then((obj) => {
-  document.getElementById('spAPIVersion_val').innerText = obj.version_git;
-})
+function fetcher(url) {
+  return itowns.Fetcher.json(url);
+}
+
+function parser(geojson, option) {
+  return itowns.GeoJsonParser.parse(geojson, option);
+}
+
+itowns.Fetcher.json(`${apiUrl}/version`)
+  .then((obj) => {
+    document.getElementById('spAPIVersion_val').innerText = obj.version_git;
+  })
   .catch(() => {
     document.getElementById('spAPIVersion_val').innerText = 'unknown';
   });
@@ -39,248 +48,292 @@ itowns.Fetcher.json(`${apiUrl}/version`).then((obj) => {
     divScaleWidget.style.width = `${pix}px`;
 } */
 
-itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
-  const overviews = json;
+async function main() {
+  try {
+    const overviews = await fetcher(`${apiUrl}/json/overviews`);
 
-  // limite du crs
-  const crs = `${overviews.crs.type}:${overviews.crs.code}`;
-  const xOrigin = overviews.crs.boundingBox.xmin;
-  const yOrigin = overviews.crs.boundingBox.ymax;
+    // limite du crs
+    const crs = `${overviews.crs.type}:${overviews.crs.code}`;
+    const xOrigin = overviews.crs.boundingBox.xmin;
+    const yOrigin = overviews.crs.boundingBox.ymax;
 
-  // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
-  if (crs !== 'EPSG:4326' && overviews.crs.proj4Definition) {
-    itowns.CRS.defs(crs, overviews.crs.proj4Definition);
-  } else {
-    throw new Error('EPSG proj4.defs not defined in overviews.json');
-  }
+    // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+    if (crs !== 'EPSG:4326' && overviews.crs.proj4Definition) {
+      itowns.CRS.defs(crs, overviews.crs.proj4Definition);
+    } else {
+      throw new Error('EPSG proj4.defs not defined in overviews.json');
+    }
 
-  // limite du dataSet
-  const xmin = overviews.dataSet.boundingBox.LowerCorner[0];
-  const xmax = overviews.dataSet.boundingBox.UpperCorner[0];
-  const ymin = overviews.dataSet.boundingBox.LowerCorner[1];
-  const ymax = overviews.dataSet.boundingBox.UpperCorner[1];
+    // limite du dataSet
+    const xmin = overviews.dataSet.boundingBox.LowerCorner[0];
+    const xmax = overviews.dataSet.boundingBox.UpperCorner[0];
+    const ymin = overviews.dataSet.boundingBox.LowerCorner[1];
+    const ymax = overviews.dataSet.boundingBox.UpperCorner[1];
 
-  const placement = {
-    coord: new itowns.Coordinates(crs, (xmax + xmin) * 0.5, (ymax + ymin) * 0.5),
-    range: 10000,
-  };
+    const placement = {
+      coord: new itowns.Coordinates(crs, (xmax + xmin) * 0.5, (ymax + ymin) * 0.5),
+      range: 10000,
+    };
 
-  // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
-  const viewerDiv = document.getElementById('viewerDiv');
+    // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+    const viewerDiv = document.getElementById('viewerDiv');
 
-  // Define geographic extent of level 0 : CRS, min/max X, min/max Y
-  const resolutionLv0 = overviews.resolution * 2 ** overviews.level.max;
+    // Define geographic extent of level 0 : CRS, min/max X, min/max Y
+    const resolutionLv0 = overviews.resolution * 2 ** overviews.level.max;
 
-  const extent = new itowns.Extent(
-    crs,
-    xOrigin, xOrigin + (overviews.tileSize.width * resolutionLv0),
-    yOrigin - (overviews.tileSize.height * resolutionLv0), yOrigin,
-  );
+    const extent = new itowns.Extent(
+      crs,
+      xOrigin, xOrigin + (overviews.tileSize.width * resolutionLv0),
+      yOrigin - (overviews.tileSize.height * resolutionLv0), yOrigin,
+    );
 
-  // Instanciate PlanarView*
-  const view = new itowns.PlanarView(viewerDiv, extent, {
-    placement,
-    maxSubdivisionLevel: 30,
-    //  disableSkirt: false
-    controls: {
-      maxAltitude: 80000000,
-      enableRotation: false,
-      enableSmartTravel: false,
-    },
-  });
-  setupLoadingScreen(viewerDiv, view);
+    // Instanciate PlanarView*
+    const view = new itowns.PlanarView(viewerDiv, extent, {
+      placement,
+      maxSubdivisionLevel: 30,
+      //  disableSkirt: false
+      controls: {
+        maxAltitude: 80000000,
+        enableRotation: false,
+        enableSmartTravel: false,
+      },
+    });
+    setupLoadingScreen(viewerDiv, view);
 
-  view.isDebugMode = true;
-  const menuGlobe = new GuiTools('menuDiv', view);
-  menuGlobe.gui.width = 300;
+    view.isDebugMode = true;
+    const menuGlobe = new GuiTools('menuDiv', view);
+    menuGlobe.gui.width = 300;
 
-  const opacity = {
-    ortho: 1,
-    graph: 0.2,
-    opi: 0.5,
-  };
+    const opacity = {
+      ortho: 1,
+      graph: 0.2,
+      opi: 0.5,
+      retouches: 0.75,
+    };
 
-  const layer = {};
-  ['ortho', 'graph', 'opi'].forEach((id) => {
-    layer[id] = {
-      name: id.charAt(0).toUpperCase() + id.slice(1),
-      config: {
-        source: {
-          url: `${apiUrl}/wmts`,
-          crs,
-          format: 'image/png',
-          name: id,
-          tileMatrixSet: overviews.identifier,
-          tileMatrixSetLimits: overviews.dataSet.limits,
+    const layer = {};
+    ['ortho', 'graph', 'opi'].forEach((id) => {
+      layer[id] = {
+        name: id.charAt(0).toUpperCase() + id.slice(1),
+        config: {
+          source: {
+            url: `${apiUrl}/wmts`,
+            crs,
+            format: 'image/png',
+            name: id,
+            tileMatrixSet: overviews.identifier,
+            tileMatrixSetLimits: overviews.dataSet.limits,
+          },
+          opacity: opacity[id],
         },
-        opacity: opacity[id],
+      };
+      layer[id].config.source = new itowns.WMTSSource(layer[id].config.source);
+      layer[id].config.source.extentInsideLimit = function extentInsideLimit() {
+        return true;
+      };
+
+      layer[id].colorLayer = new itowns.ColorLayer(layer[id].name, layer[id].config);
+      if (id === 'opi') layer[id].colorLayer.visible = false;
+      view.addLayer(layer[id].colorLayer);// .then(menuGlobe.addLayerGUI.bind(menuGlobe));
+    });
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Opi', 1);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Graph', 2);
+    // Et ouvrir l'onglet "Color Layers" par defaut ?
+
+    // Couche Retouches
+    layer.retouches = {
+      name: 'Retouches',
+      config: {
+        transparent: true,
+        opacity: 0.62,
+      },
+      optionsGeoJsonParser: {
+        in: {
+          crs: 'EPSG:2154',
+        },
+        out: {
+          crs: view.tileLayer.extent.crs,
+          buildExtent: true,
+          mergeFeatures: true,
+          withNormal: false,
+          withAltitude: false,
+        },
       },
     };
-    layer[id].config.source = new itowns.WMTSSource(layer[id].config.source);
-    layer[id].config.source.extentInsideLimit = function extentInsideLimit() {
-      return true;
-    };
 
-    layer[id].colorLayer = new itowns.ColorLayer(layer[id].name, layer[id].config);
-    if (id === 'opi') layer[id].colorLayer.visible = false;
-    view.addLayer(layer[id].colorLayer);// .then(menuGlobe.addLayerGUI.bind(menuGlobe));
-  });
-  itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
-  itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Opi', 1);
-  itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Graph', 2);
-  // Et ouvrir l'onglet "Color Layers" par defaut ?
+    const json = await fetcher(`${apiUrl}/json/activePatchs`);
 
-  // Request redraw
-  view.notifyChange();
+    const features = await parser(JSON.stringify(json), layer.retouches.optionsGeoJsonParser);
 
-  const saisie = new Saisie(view, layer, apiUrl);
-  saisie.cliche = 'unknown';
-  saisie.message = '';
-  saisie.coord = `${((xmax + xmin) * 0.5).toFixed(2)} ${((ymax + ymin) * 0.5).toFixed(2)}`;
-  saisie.color = [0, 0, 0];
-  saisie.controllers = {};
-  saisie.controllers.select = menuGlobe.gui.add(saisie, 'select');
-  saisie.controllers.cliche = menuGlobe.gui.add(saisie, 'cliche');
-  saisie.controllers.cliche.listen().domElement.parentElement.style.pointerEvents = 'none';
-  saisie.controllers.coord = menuGlobe.gui.add(saisie, 'coord');
-  saisie.controllers.coord.listen().domElement.parentElement.style.pointerEvents = 'none';
-  saisie.controllers.polygon = menuGlobe.gui.add(saisie, 'polygon');
-  saisie.controllers.undo = menuGlobe.gui.add(saisie, 'undo');
-  saisie.controllers.redo = menuGlobe.gui.add(saisie, 'redo');
-  saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
-  saisie.controllers.clear = menuGlobe.gui.add(saisie, 'save');
-  saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
-  saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
+    layer.retouches.config.source = new itowns.FileSource({ features });
+    layer.retouches.config.style = new itowns.Style({
+      fill: {
+        color: 'orange',
+        opacity: 0.5,
+      },
+      stroke: {
+        color: 'IndianRed',
+      },
+    });
 
-  viewerDiv.focus();
-  view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
+    layer.retouches.colorLayer = new itowns.ColorLayer(
+      layer.retouches.name,
+      layer.retouches.config,
+    );
+    view.addLayer(layer.retouches.colorLayer);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Retouches', 3);
+
+    // Request redraw
+    console.log('redraw');
+    view.notifyChange();
+
+    const saisie = new Saisie(view, layer, apiUrl);
+    saisie.cliche = 'unknown';
+    saisie.message = '';
+    saisie.coord = `${((xmax + xmin) * 0.5).toFixed(2)} ${((ymax + ymin) * 0.5).toFixed(2)}`;
+    saisie.color = [0, 0, 0];
+    saisie.controllers = {};
+    saisie.controllers.select = menuGlobe.gui.add(saisie, 'select');
+    saisie.controllers.cliche = menuGlobe.gui.add(saisie, 'cliche');
+    saisie.controllers.cliche.listen().domElement.parentElement.style.pointerEvents = 'none';
+    saisie.controllers.coord = menuGlobe.gui.add(saisie, 'coord');
+    saisie.controllers.coord.listen().domElement.parentElement.style.pointerEvents = 'none';
+    saisie.controllers.polygon = menuGlobe.gui.add(saisie, 'polygon');
+    saisie.controllers.undo = menuGlobe.gui.add(saisie, 'undo');
+    saisie.controllers.redo = menuGlobe.gui.add(saisie, 'redo');
+    saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
+    saisie.controllers.clear = menuGlobe.gui.add(saisie, 'save');
+    saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
+    saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
+
+    viewerDiv.focus();
+    view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
     // eslint-disable-next-line no-console
-    console.info('View initialized');
+      console.info('View initialized');
     // updateScaleWidget();
-  });
-  viewerDiv.addEventListener('mousewheel', (ev) => {
-    ev.preventDefault();
+    });
+    viewerDiv.addEventListener('mousewheel', (ev) => {
+      ev.preventDefault();
     // updateScaleWidget();
-  });
-  viewerDiv.addEventListener('mousemove', (ev) => {
-    ev.preventDefault();
-    saisie.mousemove(ev);
-    return false;
-  }, false);
-  viewerDiv.addEventListener('click', (ev) => {
-    ev.preventDefault();
-    saisie.click(ev);
-    return false;
-  }, false);
-  viewerDiv.addEventListener('auxclick', (ev) => {
-    console.log(ev.cancelable);
-    ev.preventDefault();
-    console.log('auxclick:', ev.button);
-    if (ev.button === 1) {
-      console.log('middle button clicked');
-    }
-    if (ev.button === 2) {
-      console.log('right button clicked');
-    }
-    return false;
-  }, false);
+    });
+    viewerDiv.addEventListener('mousemove', (ev) => {
+      ev.preventDefault();
+      saisie.mousemove(ev);
+      return false;
+    }, false);
+    viewerDiv.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      saisie.click(ev);
+      return false;
+    }, false);
+    viewerDiv.addEventListener('auxclick', (ev) => {
+      ev.preventDefault();
+      console.log('auxclick:', ev.button);
+      if (ev.button === 1) {
+        console.log('middle button clicked');
+      }
+      if (ev.button === 2) {
+        console.log('right button clicked');
+      }
+      return false;
+    }, false);
 
-  window.addEventListener('keydown', (ev) => {
-    saisie.keydown(ev);
-    return false;
-  });
-  window.addEventListener('keyup', (ev) => {
-    saisie.keyup(ev);
-    return false;
-  });
+    window.addEventListener('keydown', (ev) => {
+      saisie.keydown(ev);
+      return false;
+    });
+    window.addEventListener('keyup', (ev) => {
+      saisie.keyup(ev);
+      return false;
+    });
 
-  document.getElementById('recenterBtn').addEventListener('click', () => {
+    document.getElementById('recenterBtn').addEventListener('click', () => {
     // bug itowns...
     // itowns.CameraUtils.animateCameraToLookAtTarget( ... )
-    itowns.CameraUtils.transformCameraToLookAtTarget(
-      view,
-      view.camera.camera3D,
-      { coord: placement.coord, heading: 0 },
-    );
-    return false;
-  }, false);
-  document.getElementById('zoomInBtn').addEventListener('click', () => {
-    console.log('Zoom-In');
+      itowns.CameraUtils.transformCameraToLookAtTarget(
+        view,
+        view.camera.camera3D,
+        { coord: placement.coord, heading: 0 },
+      );
+      return false;
+    }, false);
+    document.getElementById('zoomInBtn').addEventListener('click', () => {
+      console.log('Zoom-In');
 
-    const { range } = itowns.CameraUtils.getTransformCameraLookingAtTarget(
-      view,
-      view.camera.camera3D,
-    );
+      const { range } = itowns.CameraUtils.getTransformCameraLookingAtTarget(
+        view,
+        view.camera.camera3D,
+      );
 
-    console.log(range);
-    itowns.CameraUtils.transformCameraToLookAtTarget(
-      view,
-      view.camera.camera3D,
-      { range: range * 0.5, heading: 0 },
-    );
-    return false;
-  });
-  document.getElementById('zoomOutBtn').addEventListener('click', () => {
-    console.log('Zoom-Out');
+      console.log(range);
+      itowns.CameraUtils.transformCameraToLookAtTarget(
+        view,
+        view.camera.camera3D,
+        { range: range * 0.5, heading: 0 },
+      );
+      return false;
+    });
+    document.getElementById('zoomOutBtn').addEventListener('click', () => {
+      console.log('Zoom-Out');
 
-    const { range } = itowns.CameraUtils.getTransformCameraLookingAtTarget(
-      view,
-      view.camera.camera3D,
-    );
+      const { range } = itowns.CameraUtils.getTransformCameraLookingAtTarget(
+        view,
+        view.camera.camera3D,
+      );
 
-    console.log(range);
-    itowns.CameraUtils.transformCameraToLookAtTarget(
-      view,
-      view.camera.camera3D,
-      { range: range * 2, heading: 0 },
-    );
-    return false;
-  });
+      console.log(range);
+      itowns.CameraUtils.transformCameraToLookAtTarget(
+        view,
+        view.camera.camera3D,
+        { range: range * 2, heading: 0 },
+      );
+      return false;
+    });
 
-  const helpContent = document.getElementById('help-content');
-  helpContent.style.visibility = 'hidden';
-  document.getElementById('help').addEventListener('click', () => {
-    helpContent.style.visibility = (helpContent.style.visibility === 'hidden') ? 'visible' : 'hidden';
-  });
+    const helpContent = document.getElementById('help-content');
+    helpContent.style.visibility = 'hidden';
+    document.getElementById('help').addEventListener('click', () => {
+      helpContent.style.visibility = (helpContent.style.visibility === 'hidden') ? 'visible' : 'hidden';
+    });
 
-  // Patch du PlanarControls pour gérer correctement les changements de curseur
-  // todo: faire une PR pour iTowns
-  view.controls.updateMouseCursorType = function updateMouseCursorType() {
+    // Patch du PlanarControls pour gérer correctement les changements de curseur
+    // todo: faire une PR pour iTowns
+    view.controls.updateMouseCursorType = function updateMouseCursorType() {
     // control state
-    const STATE = {
-      NONE: -1,
-      DRAG: 0,
-      PAN: 1,
-      ROTATE: 2,
-      TRAVEL: 3,
+      const STATE = {
+        NONE: -1,
+        DRAG: 0,
+        PAN: 1,
+        ROTATE: 2,
+        TRAVEL: 3,
+      };
+      switch (this.state) {
+        case STATE.NONE:
+          this.view.domElement.style.cursor = this.defaultCursor;
+          // this.view.domElement.style.cursor = 'auto';
+          break;
+        case STATE.DRAG:
+          if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
+          this.view.domElement.style.cursor = 'move';
+          break;
+        case STATE.PAN:
+          if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
+          this.view.domElement.style.cursor = 'cell';
+          break;
+        case STATE.TRAVEL:
+          if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
+          this.view.domElement.style.cursor = 'wait';
+          break;
+        case STATE.ROTATE:
+          if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
+          this.view.domElement.style.cursor = 'move';
+          break;
+        default:
+          break;
+      }
     };
-    switch (this.state) {
-      case STATE.NONE:
-        this.view.domElement.style.cursor = this.defaultCursor;
-        // this.view.domElement.style.cursor = 'auto';
-        break;
-      case STATE.DRAG:
-        if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
-        this.view.domElement.style.cursor = 'move';
-        break;
-      case STATE.PAN:
-        if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
-        this.view.domElement.style.cursor = 'cell';
-        break;
-      case STATE.TRAVEL:
-        if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
-        this.view.domElement.style.cursor = 'wait';
-        break;
-      case STATE.ROTATE:
-        if (this.view.domElement.style.cursor !== 'wait') this.defaultCursor = this.view.domElement.style.cursor;
-        this.view.domElement.style.cursor = 'move';
-        break;
-      default:
-        break;
-    }
-  };
-})
-  .catch((err) => {
+  } catch (err) {
     console.log(`${err.name}: ${err.message}`);
     if (`${err.name}: ${err.message}` === 'TypeError: Failed to fetch') {
       const newApiUrl = window.prompt(`API non accessible à l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl);
@@ -289,4 +342,6 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     } else {
       window.alert(err);
     }
-  });
+  }
+}
+main();

--- a/rok4.js
+++ b/rok4.js
@@ -2,6 +2,7 @@ const path = require('path');
 const debug = require('debug')('rok4');
 
 function getTileRoot(X, Y, Z, pathDepth) {
+  debug('~~~getTileRoot');
   debug(X, Y, Z, pathDepth);
   const strX = Math.trunc(X).toString(36).padStart(pathDepth + 1, 0).toUpperCase();
   const strY = Math.trunc(Y).toString(36).padStart(pathDepth + 1, 0).toUpperCase();
@@ -11,9 +12,10 @@ function getTileRoot(X, Y, Z, pathDepth) {
     url = path.join(url, strX[i] + strY[i]);
   }
   debug(url);
-  url = path.join(url, strX[pathDepth] + strY[pathDepth]);
-  debug(url);
-  return url;
+  return {
+    dirPath: url,
+    fileName: strX[pathDepth] + strY[pathDepth],
+  };
 }
 
 exports.getTileRoot = getTileRoot;

--- a/routes/file.js
+++ b/routes/file.js
@@ -13,7 +13,7 @@ const parentDir = `${global.dir_cache}`;
 router.get('/json/:typefile', [
   param('typefile')
     .exists().withMessage(createErrMsg.missingParameter('typefile'))
-    .isIn(['overviews', 'test'])
+    .isIn(['overviews', 'activePatchs', 'test'])
     .withMessage(createErrMsg.invalidParameter('typefile')),
 ], validateParams,
 (req, res) => {

--- a/routes/graph.js
+++ b/routes/graph.js
@@ -43,8 +43,8 @@ router.get('/graph', [
   const Ty = Math.floor(Py / overviews.tileSize.height);
   const I = Math.floor(Px - Tx * overviews.tileSize.width);
   const J = Math.floor(Py - Ty * overviews.tileSize.height);
-
-  const url = path.join(global.dir_cache, 'graph', `${rok4.getTileRoot(Tx, Ty, lvlMax, overviews.pathDepth)}.png`);
+  const tileRoot = rok4.getTileRoot(Tx, Ty, lvlMax, overviews.pathDepth);
+  const url = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}.png`);
   debug(url);
   // _graph.png`;
   if (!fs.existsSync(url)) {

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -657,7 +657,7 @@ router.put('/patchs/save', [], (req, res) => {
   debug('features in activePatchs:', req.app.activePatchs.features.length);
   debug('features in unactivePatchs:', req.app.unactivePatchs.features.length);
   debug('fin du save');
-  res.status(200).send('save: all actives patches saved');
+  res.status(200).send('save: all active patches saved');
 });
 
 module.exports = router;

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -497,13 +497,9 @@ router.put('/patchs/clear', [], (req, res) => {
       const urlGraphSelected = path.join(graphDir, `${tileRoot.fileName}_orig.png`);
       const urlOrthoSelected = path.join(orthoDir, `${tileRoot.fileName}_orig.png`);
 
+      // include('_') suffit car on veut tout supprimer (meme sur les autres tuiles)
       const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes('_') && !filename.endsWith('orig.png')));
       // suppression des images intermediaires
-      debug("______________")
-      debug(graphDir)
-      debug(arrayLinkGraph)
-      debug(tileRoot)
-      debug("^^^^^^^^^^^^^^")
       arrayLinkGraph.forEach((file) => fs.unlinkSync(
         path.join(graphDir, file),
       ));
@@ -562,6 +558,106 @@ router.put('/patchs/clear', [], (req, res) => {
   debug('features in unactivePatchs:', req.app.unactivePatchs.features.length);
   debug('fin du clear');
   res.status(200).send('clear: all patches deleted');
+});
+
+router.put('/patchs/save', [], (req, res) => {
+  debug('~~~PUT patchs/save');
+  // pour chaque patch de req.app.activePatchs.features
+  if (req.app.activePatchs.features.length === 0) {
+    debug('nothing to save');
+    res.status(201).send('nothing to save');
+    return;
+  }
+  const { overviews } = req.app;
+  const { features } = req.app.activePatchs;
+
+  const lastPatchId = req.app.activePatchs.features[req.app.activePatchs.features.length - 1]
+    .properties.patchId;
+  debug('lastPatchId:', lastPatchId);
+
+  features.forEach((feature) => {
+    // trouver la liste des tuiles concernées par ces patchs
+    const { tiles } = feature.properties;
+    debug(tiles.length, 'tuiles impactées');
+    // pour chaque tuile, on écrase la version orig
+    tiles.forEach((tile) => {
+      const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
+      // on récupère l'historique de cette tuile
+      const urlHistory = path.join(global.dir_cache, 'opi', tileRoot.dirPath, `${tileRoot.fileName}_history.packo`);
+      const history = fs.readFileSync(`${urlHistory}`).toString().split(';');
+
+      debug('____');
+      debug(tile);
+      debug(history);
+
+      // on récupère la version à restaurer
+      const idSelected = history[history.length - 1];
+      debug('  version sauvegardée pour la tuile :', idSelected);
+
+      // on supprime chaque image sauf l'image active (pour graph et ortho)
+      const graphDir = path.join(global.dir_cache, 'graph', tileRoot.dirPath);
+      const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`)));
+      arrayLinkGraph.forEach((file) => {
+        if (file.split('_')[1] !== `${idSelected}.png`) {
+          debug('supp', file);
+          fs.unlinkSync(path.join(graphDir, file));
+        }
+      });
+      const orthoDir = path.join(global.dir_cache, 'ortho', tileRoot.dirPath);
+      const arrayLinkOrtho = fs.readdirSync(orthoDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`)));
+      arrayLinkOrtho.forEach((file) => {
+        if (file.split('_')[1] !== `${idSelected}.png`) {
+          debug('supp', file);
+          fs.unlinkSync(path.join(orthoDir, file));
+        }
+      });
+      // on renomme l'image active en _orig
+      fs.renameSync(
+        path.join(graphDir, `${tileRoot.fileName}_${idSelected}.png`),
+        path.join(graphDir, `${tileRoot.fileName}_orig.png`),
+      );
+      fs.renameSync(
+        path.join(orthoDir, `${tileRoot.fileName}_${idSelected}.png`),
+        path.join(orthoDir, `${tileRoot.fileName}_orig.png`),
+      );
+      // remise à zéro de l'historique de la tuile
+      fs.writeFileSync(`${urlHistory}`, 'orig');
+    });
+  });
+
+  req.app.unactivePatchs.features.forEach((feature) => {
+    // trouver la liste des tuiles concernées par ces patchs
+    const { tiles } = feature.properties;
+    debug(tiles.size, 'tuiles impactées');
+    // pour chaque tuile, on efface les images du redo
+    tiles.forEach((tile) => {
+      const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
+
+      const graphDir = path.join(global.dir_cache, 'graph', tileRoot.dirPath);
+      const orthoDir = path.join(global.dir_cache, 'ortho', tileRoot.dirPath);
+
+      const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`) && !filename.endsWith('orig.png')));
+      // suppression des images intermediaires
+      arrayLinkGraph.forEach((file) => fs.unlinkSync(
+        path.join(graphDir, file),
+      ));
+      const arrayLinkOrtho = fs.readdirSync(orthoDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`) && !filename.endsWith('orig.png')));
+      // suppression des images intermediaires
+      arrayLinkOrtho.forEach((file) => fs.unlinkSync(
+        path.join(orthoDir, file),
+      ));
+    });
+  });
+  const date = new Date(Date.now()).toLocaleString().replace(/ |à|:|\//g, '').substr(0, 12);
+  fs.writeFileSync(path.join(global.dir_cache, `save_${date}.json`), JSON.stringify(req.app.activePatchs, null, 4));
+  req.app.activePatchs.features = [];
+  req.app.unactivePatchs.features = [];
+  fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(req.app.activePatchs, null, 4));
+  fs.writeFileSync(path.join(global.dir_cache, 'unactivePatchs.json'), JSON.stringify(req.app.unactivePatchs, null, 4));
+  debug('features in activePatchs:', req.app.activePatchs.features.length);
+  debug('features in unactivePatchs:', req.app.unactivePatchs.features.length);
+  debug('fin du save');
+  res.status(200).send('save: all actives patches saved');
 });
 
 module.exports = router;

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -648,8 +648,8 @@ router.put('/patchs/save', [], (req, res) => {
       ));
     });
   });
-  const date = new Date(Date.now()).toLocaleString().replace(/ |à|:|\//g, '').substr(0, 14);
-  fs.writeFileSync(path.join(global.dir_cache, `save_${date}.json`), JSON.stringify(req.app.activePatchs, null, 4));
+  const date = new Date(Date.now()).toISOString().replace(/-|T|:/g, '').substr(0, 14);
+  fs.writeFileSync(path.join(global.dir_cache, `save_${date}Z.json`), JSON.stringify(req.app.activePatchs, null, 4));
   req.app.activePatchs.features = [];
   req.app.unactivePatchs.features = [];
   fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(req.app.activePatchs, null, 4));

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -648,7 +648,7 @@ router.put('/patchs/save', [], (req, res) => {
       ));
     });
   });
-  const date = new Date(Date.now()).toLocaleString().replace(/ |à|:|\//g, '').substr(0, 12);
+  const date = new Date(Date.now()).toLocaleString().replace(/ |à|:|\//g, '').substr(0, 14);
   fs.writeFileSync(path.join(global.dir_cache, `save_${date}.json`), JSON.stringify(req.app.activePatchs, null, 4));
   req.app.activePatchs.features = [];
   req.app.unactivePatchs.features = [];

--- a/routes/wmts.js
+++ b/routes/wmts.js
@@ -274,7 +274,7 @@ router.get('/wmts', [
       mime = Jimp.MIME_JPEG; // "image/jpeg"
     }
     const tileRoot = rok4.getTileRoot(TILECOL, TILEROW, TILEMATRIX, overviews.pathDepth);
-    let url = path.join(global.dir_cache, layerName, tileRoot);
+    let url = path.join(global.dir_cache, layerName, tileRoot.dirPath, tileRoot.fileName);
     if (LAYER === 'opi') {
       if (!Name) {
         url += `_${overviews.list_OPI[0]}`;
@@ -307,7 +307,7 @@ router.get('/wmts', [
     debug('~~~GetFeatureInfo');
     debugFeatureInfo(LAYER, TILEMATRIX, TILEROW, TILECOL, I, J);
     const tileRoot = rok4.getTileRoot(TILECOL, TILEROW, TILEMATRIX, overviews.pathDepth);
-    const url = `${path.join(global.dir_cache, 'graph', tileRoot)}.png`;
+    const url = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}.png`);
 
     if (!fs.existsSync(url)) {
       const erreur = new Error();

--- a/serveur.js
+++ b/serveur.js
@@ -55,7 +55,7 @@ try {
   app.overviews = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'overviews.json')));
 
   try {
-    app.activePatchs = JSON.parse(fs.readFileSync(`${global.dir_cache}/activePatchs.json`));
+    app.activePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'activePatchs.json')));
   } catch (err) {
     app.activePatchs = {
       type: 'FeatureCollection',
@@ -68,11 +68,11 @@ try {
       },
       features: [],
     };
-    fs.writeFileSync(`${global.dir_cache}/activePatchs.json`, JSON.stringify(app.activePatchs));
+    fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(app.activePatchs, null, 4));
   }
 
   try {
-    app.unactivePatchs = JSON.parse(fs.readFileSync(`${global.dir_cache}/unactivePatchs.json`));
+    app.unactivePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'unactivePatchs.json')));
   } catch (err) {
     app.unactivePatchs = {
       type: 'FeatureCollection',
@@ -85,7 +85,7 @@ try {
       },
       features: [],
     };
-    fs.writeFileSync(`${global.dir_cache}/unactivePatchs.json`, JSON.stringify(app.unactivePatchs));
+    fs.writeFileSync(path.join(global.dir_cache, 'unactivePatchs.json'), JSON.stringify(app.unactivePatchs, null, 4));
   }
 
   app.use(cors());

--- a/test/patch.js
+++ b/test/patch.js
@@ -185,7 +185,7 @@ describe('Patch', () => {
   });
 
   describe('PUT /patchs/save', () => {
-    it("should return 'save: all actives patches saved'", (done) => {
+    it("should return 'save: all active patches saved'", (done) => {
       // first add a patch
       chai.request(server)
         .post('/patch')
@@ -238,7 +238,7 @@ describe('Patch', () => {
                     .end((err3, res3) => {
                       should.not.exist(err3);
                       res3.should.have.status(200);
-                      res3.text.should.equal('save: all actives patches saved');
+                      res3.text.should.equal('save: all active patches saved');
                       done();
                     });
                 });


### PR DESCRIPTION
Ré écrite sous la PR #117 (partie itowns) et #116 (partie API)

[Précision polygones affichés : en attente Fix itowns]

Cette PR ajoute deux fonctionnalités :

- l'ajout d'une couche vectorielle 'retouches' permettant la visualisation de l'ensemble des patchs actifs (à tout instants)
- un bouton 'save' permettant la sauvegarde (et la pérennisation) de tous les patchs actifs, un fichier save_'date'.json est crée contenant les polygones de retouches sauvegardés.

Autre modification
- rok4.js => return en 2 parties dirPath et fileName (et non plus une unique string)
- MaJ des tests pour la route Save et Clear
- dans serveur.js réécriture des chemin à l'aide de path.join
