### PR TITLE
gestion du mode developpeur + serveur static des pages itowns par nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,7 @@ En production il faut exécuter :
 ```shell
 npm run build
 ```
-avant de lancer le serveur en utilisant :
-```shell
-python3 -m http.server
-```
+Le serveur est automatiquement pris en charge par nodejs: http://localhost:8081/itowns
 
 ### Principe de fonctionnement
 

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -284,7 +284,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     if (`${err.name}: ${err.message}` === 'TypeError: Failed to fetch') {
       const newApiUrl = window.prompt(`API non accessible à l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl);
       const apiUrlSplit = newApiUrl.split('/')[2].split(':');
-      window.location.assign(`${window.location.origin}?serverapi=${apiUrlSplit[0]}&portapi=${apiUrlSplit[1]}`);
+      window.location.assign(`${window.location.href.split('?')[0]}?serverapi=${apiUrlSplit[0]}&portapi=${apiUrlSplit[1]}`);
     } else {
       window.alert(err);
     }

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -472,6 +472,11 @@ router.put('/patch/redo', [], (req, res) => {
 
 router.put('/patchs/clear', [], (req, res) => {
   debug('~~~PUT patchs/clear');
+  if (!global.mode_dev) {
+    debug('unauthorized');
+    res.status(201).send('unauthorized');
+    return;
+  }
   // pour chaque patch de req.app.activePatchs.features
   if (req.app.activePatchs.features.length === 0) {
     debug('nothing');

--- a/serveur.js
+++ b/serveur.js
@@ -26,11 +26,17 @@ const { argv } = require('yargs')
     alias: 's',
     describe: "API server (default: 'localhost')",
   })
+  .option('dev', {
+    alias: 'd',
+    describe: 'Pour activer le mode développeur',
+  })
   .help()
   .alias('help', 'h');
 
 const app = express();
 
+global.mode_dev = !!argv.dev;
+debug.log('mode développeur : ', global.mode_dev);
 global.dir_cache = argv.cache ? argv.cache : 'cache';
 debug.log(`using cache directory: ${global.dir_cache}`);
 
@@ -118,6 +124,8 @@ try {
   app.use('/', file);
   app.use('/', patch);
   app.use('/', misc);
+
+  app.use('/itowns', express.static('itowns'));
 
   module.exports = app.listen(PORT, () => {
     debug.log(`URL de l'api : ${app.urlApi} \nURL de la documentation swagger : ${app.urlApi}/doc`);

--- a/test/patch.js
+++ b/test/patch.js
@@ -131,23 +131,33 @@ describe('Patch', () => {
     });
   });
   describe('PUT /patchs/clear', () => {
-    it("should return 'clear: all patches deleted'", (done) => {
-      chai.request(server)
-        .put('/patchs/clear')
-        .end((err, res) => {
-          should.not.exist(err);
-          res.should.have.status(200);
-          res.text.should.equal('clear: all patches deleted');
-          done();
-        });
-    });
-    it("should return a warning (code 201): 'nothing to clear'", (done) => {
+    // it("should return 'clear: all patches deleted'", (done) => {
+    //   chai.request(server)
+    //     .put('/patchs/clear')
+    //     .end((err, res) => {
+    //       should.not.exist(err);
+    //       res.should.have.status(200);
+    //       res.text.should.equal('clear: all patches deleted');
+    //       done();
+    //     });
+    // });
+    // it("should return a warning (code 201): 'nothing to clear'", (done) => {
+    //   chai.request(server)
+    //     .put('/patchs/clear')
+    //     .end((err, res) => {
+    //       should.not.exist(err);
+    //       res.should.have.status(201);
+    //       res.text.should.equal('nothing to clear');
+    //       done();
+    //     });
+    // });
+    it("should return a warning (code 201): 'unauthorized'", (done) => {
       chai.request(server)
         .put('/patchs/clear')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(201);
-          res.text.should.equal('nothing to clear');
+          res.text.should.equal('unauthorized');
           done();
         });
     });


### PR DESCRIPTION
Cette PR permet de servir la partie iTowns via le serveur nodejs, c'est à dire en n'utilisant ni webpack ni python. Cela simplifie le déploiement.

On a également ajouté une option 'mode développeur' dans les paramètres du serveur pour autoriser ou pas la commande *clear*:
Options :
  --cache, -c   cache directory (default: 'cache')
  --port, -p    API port (default: '8081')
  --server, -s  API server (default: 'localhost')
  --dev, -d     Pour activer le mode développeur
  --help, -h    Affiche l'aide

Attention: le menu reste visible pour le moment dans iTowns, par contre, toutes les requêtes vont donner un code d'erreur 201 avec le message : 'unauthorized'.