### PR TITLE
[itowns] Echelle et zoom

### DIFF
--- a/itowns/css/View.css
+++ b/itowns/css/View.css
@@ -1,0 +1,167 @@
+/* GENERAL */
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    color: #202020;
+    font-size: 13px;
+}
+
+body {
+    overflow: hidden;
+}
+
+.scroll-section {
+    height: 100%;
+    position: absolute;
+}
+
+#description {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    overflow: hidden;
+}
+
+#description, .text {
+    z-index: 1;
+    color: #eee;
+    font: 16px 'Lucida Grande',sans-serif;
+    max-width: 40%;
+    background: #1a1a1a;
+    opacity: 0.8;
+    padding: 10px;
+}
+
+#description p, #description ul {
+    margin: 0px;
+}
+
+.text a {
+    color: lightcoral;
+}
+
+.text a:hover {
+    color: #f0c0c0;
+}
+
+.text > ul {
+    padding: 0 2rem;
+}
+
+@media (max-width: 600px) {
+    .text {
+        display: none;
+    }
+}
+
+/* IFRAME/EXAMPLE CONTENT */
+#viewerDiv {
+    height: 100%;
+}
+
+#viewerDiv>canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+#menuDiv {
+    position: absolute;
+    left: 10px;
+    top: 0px;
+    z-index: 0;
+}
+
+#menuDiv, .ac {
+/* Disable select DAT.gui */
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    z-index: 2 !important;
+}
+
+#miniDiv {
+    display: block;
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    left: 20;
+    bottom: 20;
+    color: white;
+}
+
+#divScale {
+    display: block;
+    position: absolute;
+    right: 135px;
+    bottom: 20;
+    text-align: center;
+    width: 204px;
+    height: 37px;
+    color: black;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 16px;
+    user-select: none;
+}
+
+#spanScaleWidget {
+    display: block;
+    /* position: absolute;
+    right: 135px;
+    bottom: 20; */
+    border: 2px solid black;
+    border-top: none;
+    text-align: center;
+    background-image: linear-gradient(rgba(200, 200, 200, 0.3), rgba(200, 200, 200, 0.3));
+    width: 200px;
+    height: 18px;
+    color: black;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 16px;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+#spanZoomWidget {
+    display: block;
+    text-align: center;
+    background-image: linear-gradient(rgba(200, 200, 200, 0.3), rgba(200, 200, 200, 0.3));
+    width: 100px;
+    height: 18px;
+    color: black;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 16px;
+    margin: 0 auto;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.tooltip {
+    display: none;
+    background-image: linear-gradient(rgba(80, 80, 80,0.95), rgba(60, 60, 60,0.95));
+    box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.5);
+    margin-top: 20px;
+    margin-left: 20px;
+    padding: 10px;
+    position: absolute;
+    z-index: 1000;
+    color: #CECECE;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 14px;
+    line-height: 18px;
+    text-align: left;
+}
+
+.tooltip li, .coord {
+    font-size: 12px;
+    padding-left: 20px;
+    color: #93B7C0;
+    text-shadow: 0px 1px 0px rgba(200,200,200,.3), 0px -1px 0px rgba(30,30,30,.7);
+}

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -4,12 +4,10 @@
     <title>Mosaique</title>
 
     <meta charset="UTF-8">
-    <link rel="stylesheet" type="text/css" href="node_modules/itowns/examples/css/example.css">
     <link rel="stylesheet" type="text/css" href="node_modules/itowns/examples/css/LoadingScreen.css">
+    <link rel="stylesheet" type="text/css" href="css/View.css">
     <link rel="stylesheet" type="text/css" href="css/Buttons.css">
-    <!-- <link rel="stylesheet" type="text/css" href="css/APIVersion.css"> -->
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- <meta name="viewport" content="width=device-width, initial-scale=1.0"> -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
 </head>
 
@@ -29,8 +27,10 @@
     <div id="help-content">
         <p><strong>API : </strong><span id="spAPIVersion_val">???</span>
     </div>
-    <!-- <div id="divAPIVersion"> API <span id="spAPIVersion_val">???</span> </div> -->
-    <span id="divScaleWidget"> Scale </span>
+    <div id="divScale">
+        <span id="spanScaleWidget"> Scale </span>
+        <span id="spanZoomWidget"> Zoom </span>
+    </div>
     <!-- <div id="miniDiv"></div> -->
     <script src="node_modules/itowns/examples/js/GUI/GuiTools.js"></script>
     <!-- <script src="node_modules/itowns/dist/itowns.js"></script> -->

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -30,7 +30,7 @@
         <p><strong>API : </strong><span id="spAPIVersion_val">???</span>
     </div>
     <!-- <div id="divAPIVersion"> API <span id="spAPIVersion_val">???</span> </div> -->
-    <!--<span id="divScaleWidget"> Scale </span>-->
+    <span id="divScaleWidget"> Scale </span>
     <!-- <div id="miniDiv"></div> -->
     <script src="node_modules/itowns/examples/js/GUI/GuiTools.js"></script>
     <!-- <script src="node_modules/itowns/dist/itowns.js"></script> -->

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -67,6 +67,8 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     ycenter - viewerDiv.height * resolInit * 0.5, ycenter + viewerDiv.height * resolInit * 0.5,
   );
 
+  const resolLvMin = overviews.resolution * 2 ** (overviews.level.max - overviews.level.min);
+
   // Instanciate PlanarView*
   const view = new itowns.PlanarView(viewerDiv, extent, {
     camera: {
@@ -78,6 +80,8 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     controls: {
       enableSmartTravel: false,
       zoomFactor: 2,
+      maxResolution: 0.5 * overviews.resolution,
+      minResolution: 2 * resolLvMin,
     },
   });
 
@@ -243,20 +247,22 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   }, false);
   document.getElementById('zoomInBtn').addEventListener('click', () => {
     console.log('Zoom-In');
-    view.camera.camera3D.zoom *= 2;
-    view.camera.camera3D.updateProjectionMatrix();
-    view.notifyChange(view.camera.camera3D);
-    console.log(view.camera.camera3D.zoom);
-    updateScaleWidget();
+    if (view.getPixelsToMeters() > overviews.resolution) {
+      view.camera.camera3D.zoom *= 2;
+      view.camera.camera3D.updateProjectionMatrix();
+      view.notifyChange(view.camera.camera3D);
+      updateScaleWidget();
+    }
     return false;
   });
   document.getElementById('zoomOutBtn').addEventListener('click', () => {
     console.log('Zoom-Out');
-    view.camera.camera3D.zoom *= 0.5;
-    view.camera.camera3D.updateProjectionMatrix();
-    view.notifyChange(view.camera.camera3D);
-    console.log(view.camera.camera3D.zoom);
-    updateScaleWidget();
+    if (view.getPixelsToMeters() < resolLvMin) {
+      view.camera.camera3D.zoom *= 0.5;
+      view.camera.camera3D.updateProjectionMatrix();
+      view.notifyChange(view.camera.camera3D);
+      updateScaleWidget();
+    }
     return false;
   });
 

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -71,10 +71,17 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     yOrigin - (overviews.tileSize.height * resolutionLv0), yOrigin,
   );
 
+  const dezoomInitial = 4;
+  const resolInit = overviews.resolution * 2 ** dezoomInitial;
+  const xcenter = (xmin + xmax) * 0.5;
+  const ycenter = (ymin + ymax) * 0.5;
+
+  viewerDiv.height = viewerDiv.clientHeight;
+  viewerDiv.width = viewerDiv.clientWidth;
   const placement = new itowns.Extent(
     crs,
-    xmin, xmax,
-    ymin, ymax,
+    xcenter - viewerDiv.width * resolInit * 0.5, xcenter + viewerDiv.width * resolInit * 0.5,
+    ycenter - viewerDiv.height * resolInit * 0.5, ycenter + viewerDiv.height * resolInit * 0.5,
   );
 
   // Instanciate PlanarView*
@@ -86,11 +93,11 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     maxSubdivisionLevel: 30,
     disableSkirt: true,
     controls: {
-      // maxAltitude: 80000000,
-      // enableRotation: false,
       enableSmartTravel: false,
+      zoomFactor: 2,
     },
   });
+
   setupLoadingScreen(viewerDiv, view);
 
   view.isDebugMode = true;
@@ -139,7 +146,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   const saisie = new Saisie(view, layer, apiUrl);
   saisie.cliche = 'unknown';
   saisie.message = '';
-  saisie.coord = `${((xmax + xmin) * 0.5).toFixed(2)},${((ymax + ymin) * 0.5).toFixed(2)}`;
+  saisie.coord = `${xcenter.toFixed(2)},${ycenter.toFixed(2)}`;
   saisie.color = [0, 0, 0];
   saisie.controllers = {};
   saisie.controllers.select = menuGlobe.gui.add(saisie, 'select');
@@ -240,7 +247,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
       view,
       view.camera.camera3D,
       {
-        coord: new itowns.Coordinates(crs, (xmax + xmin) * 0.5, (ymax + ymin) * 0.5),
+        coord: new itowns.Coordinates(crs, xcenter, ycenter),
         heading: 0,
       },
     );

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -22,24 +22,22 @@ itowns.Fetcher.json(`${apiUrl}/version`).then((obj) => {
     document.getElementById('spAPIVersion_val').innerText = 'unknown';
   });
 
-/*         function updateScaleWidget() {
-    var pix = 200;
-    const point1 = new itowns.THREE.Vector3();
-    const point2 = new itowns.THREE.Vector3();
-    const mousePosition = new itowns.THREE.Vector2();
-    mousePosition.set(0, 0);
-    view.getPickingPositionFromDepth(mousePosition, point1);
-    mousePosition.set(pix, 0);
-    view.getPickingPositionFromDepth(mousePosition, point2);
-    var value = point1.distanceTo(point2);
-    var unit = 'm';
-    if (value >= 1000) {
-        value /= 1000;
-        unit = 'km';
-    }
-    divScaleWidget.innerHTML = `${value.toFixed(2)} ${unit}`;
-    divScaleWidget.style.width = `${pix}px`;
-} */
+const divScaleWidget = document.getElementById('divScaleWidget');
+const scalePxlSize = 200;
+function updateScaleWidget(view) {
+  let value = view.getPixelsToMeters(scalePxlSize);
+  let unit = 'm';
+  if (value >= 1000) {
+    value /= 1000;
+    unit = 'km';
+  }
+  if (value <= 1) {
+    value *= 100;
+    unit = 'cm';
+  }
+  divScaleWidget.innerHTML = `${value.toFixed(2)} ${unit}`;
+  divScaleWidget.style.width = `${scalePxlSize}px`;
+}
 
 // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
 const viewerDiv = document.getElementById('viewerDiv');
@@ -160,12 +158,17 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
     // eslint-disable-next-line no-console
     console.info('View initialized');
-    // updateScaleWidget();
+    updateScaleWidget(view);
   });
-  viewerDiv.addEventListener('mousewheel', (ev) => {
-    ev.preventDefault();
-    // updateScaleWidget();
+  view.addEventListener(itowns.PLANAR_CONTROL_EVENT.MOVED, () => {
+    // eslint-disable-next-line no-console
+    console.info('View moved');
+    updateScaleWidget(view);
   });
+  // viewerDiv.addEventListener('mousewheel', (ev) => {
+  //   ev.preventDefault();
+  //   updateScaleWidget(view);
+  // });
   viewerDiv.addEventListener('mousemove', (ev) => {
     ev.preventDefault();
     saisie.mousemove(ev);
@@ -249,6 +252,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     view.camera.camera3D.updateProjectionMatrix();
     view.notifyChange(view.camera.camera3D);
     console.log(view.camera.camera3D.zoom);
+    updateScaleWidget(view);
     return false;
   });
   document.getElementById('zoomOutBtn').addEventListener('click', () => {
@@ -257,6 +261,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     view.camera.camera3D.updateProjectionMatrix();
     view.notifyChange(view.camera.camera3D);
     console.log(view.camera.camera3D.zoom);
+    updateScaleWidget(view);
     return false;
   });
 


### PR DESCRIPTION
Objectifs : 
- Ajouter l'échelle et le niveau de zoom (de façon dynamique)
- Limiter les zooms aux niveaux présent dans le cache (exactement ou avec une marge ?)


Modifications :
- l'échelle ainsi que le niveau de zoom ont été ajoutés a la carte
- le zoom initial est un dézoom 4 (sujet à discussion)
- les zooms et dézooms sont actuellement limités aux niveaux renseignés dans le fichier overviews avec une marge de +/-1 (sujet à discussion)

- itowns (bug et amélioration) :
    - ~~modifier la taille de la fenêtre change le niveau de zoom de façon incontrôlable~~ (corrigé dans itowns 2.32)
    - ~~pas de moyen actuellement de limiter les zoom in et out~~ (ajouté dans itowns 2.32)
    - ~~bug lors d'un long zoom et clique molette ou droit~~(corrigé dans itowns 2.33)


 