### PR TITLE
[itowns] clique molette et deplacement

### DIFF
--- a/itowns/index.js
+++ b/itowns/index.js
@@ -176,18 +176,13 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     saisie.click(ev);
     return false;
   }, false);
-  viewerDiv.addEventListener('auxclick', (ev) => {
-    console.log(ev.cancelable);
-    ev.preventDefault();
-    console.log('auxclick:', ev.button);
+  viewerDiv.addEventListener('mousedown', (ev) => {
     if (ev.button === 1) {
       console.log('middle button clicked');
+      view.controls.initiateDrag();
+      view.controls.updateMouseCursorType();
     }
-    if (ev.button === 2) {
-      console.log('right button clicked');
-    }
-    return false;
-  }, false);
+  });
 
   // check if string is in "x,y" format with x and y positive floats
   // return "null" if incorrect string format, otherwise [x, y] array


### PR DESCRIPTION
(basée sur PR #118 MaJ Itowns 2.32)

Objectif:
- permettre le déplacement lors d'un clique molette long.



Question subsidiaire:
- Quel était le problème avec la mise à jour du curseur dans l'ancienne version itowns ?
  J'ai l'impression qu'il n'y a plus de problème (et la suppression des lignes supplémentaire résout un bug d'affichage que j'ai rencontré lors d'une saisie de coordonnées.)  => Reglé dans la PR #110 