### PR TITLE
Adapt SQL request

### DIFF
--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -348,10 +348,13 @@ def create_ortho_and_graph_1arg(arg):
 
             # on rasterise la partie du graphe qui concerne ce cliche
             db_graph = gdal.OpenEx(arg['dbOption']['connString'], gdal.OF_VECTOR)
+            # requete sql adaptee pour marcher avec des nomenclatures du type
+            # 20FD1325x00001_02165 ou OPI_20FD1325x00001_02165
             gdal.Rasterize(mask,
                            db_graph,
                            SQLStatement='select geom from '
-                           + arg['dbOption']['table'] + ' where cliche = \'' + stem + '\'')
+                           + arg['dbOption']['table']
+                           + ' where cliche like \'%' + stem[-20:] + '%\'')
             img_mask = mask.GetRasterBand(1).ReadAsArray()
             # si mask est vide, on ne fait rien
             val_max = np.amax(img_mask)


### PR DESCRIPTION
J'ai modifié la requête SQL pour s'adapter aussi au cas où les noms des clichés dans le shp (et donc dans la BD) ne sont pas identiques aux noms des OPIs (et ainsi éviter d'avoir des requêtes sans réponse qui génèrent des tuiles ortho et graph noires, sans aucune information, dans le cache).