### PR TITLE
[itowns] Patch : Sauvegarde et Visualisation => #148

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -259,6 +259,7 @@ paths:
             type: string
             enum:
               - overviews
+              - activePatchs
 
       responses:
         '200':

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -374,7 +374,7 @@ class Saisie {
 
   clear() {
     if (this.currentStatus === status.WAITING) return;
-    const ok = window.confirm('Voulez-vous effacer toutes les modifications?');
+    const ok = window.confirm('Voulez-vous effacer toutes les modifications ?');
     if (!ok) return;
     console.log('clear');
     this.currentStatus = status.WAITING;
@@ -382,6 +382,29 @@ class Saisie {
     this.message = 'calcul en cours';
 
     fetch(`${this.apiUrl}/patchs/clear?`,
+      {
+        method: 'PUT',
+      }).then((res) => {
+      this.cancelcurrentPolygon();
+      if (res.status === 200) {
+        this.refreshView(['ortho', 'graph']);
+      }
+      res.text().then((msg) => {
+        this.message = msg;
+      });
+    });
+  }
+
+  save() {
+    if (this.currentStatus === status.WAITING) return;
+    const ok = window.confirm('Voulez-vous sauvegarder toutes les modifications ?');
+    if (!ok) return;
+    console.log('save');
+    this.currentStatus = status.WAITING;
+    document.getElementById('viewerDiv').style.cursor = 'wait';
+    this.message = 'calcul en cours';
+
+    fetch(`${this.apiUrl}/patchs/save?`,
       {
         method: 'PUT',
       }).then((res) => {

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -11,11 +11,11 @@ const status = {
   WAITING: 4,
 };
 
-function fetcher(url) {
+export function fetcher(url) {
   return itowns.Fetcher.json(url);
 }
 
-function parser(geojson, option) {
+export function parser(geojson, option) {
   return itowns.GeoJsonParser.parse(geojson, option);
 }
 
@@ -36,11 +36,11 @@ class Saisie {
   async refreshView(layers) {
     // Pour le moment on force le rechargement complet des couches
 
-    let redrawRetouches = false;
+    let redrawPatches = false;
 
     layers.forEach((id) => {
       this.view.removeLayer(this.layer[id].colorLayer.id);
-      if (id !== 'retouches') {
+      if (id !== 'patches') {
         this.layer[id].config.opacity = this.layer[id].colorLayer.opacity;
         this.layer[id].colorLayer = new itowns.ColorLayer(
           this.layer[id].name,
@@ -48,26 +48,26 @@ class Saisie {
         );
         this.view.addLayer(this.layer[id].colorLayer);
       } else {
-        redrawRetouches = true;
+        redrawPatches = true;
       }
     });
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Ortho', 0);
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Opi', 1);
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Graph', 2);
 
-    if (redrawRetouches) {
-      this.layer.retouches.config.opacity = this.layer.retouches.colorLayer.opacity;
+    if (redrawPatches) {
+      this.layer.patches.config.opacity = this.layer.patches.colorLayer.opacity;
 
       const json = await fetcher(`${this.apiUrl}/json/activePatchs`);
       const features = await parser(JSON.stringify(json),
-        this.layer.retouches.optionsGeoJsonParser);
-      this.layer.retouches.config.source = new itowns.FileSource({ features });
-      this.layer.retouches.colorLayer = new itowns.ColorLayer(
-        this.layer.retouches.name,
-        this.layer.retouches.config,
+        this.layer.patches.optionsGeoJsonParser);
+      this.layer.patches.config.source = new itowns.FileSource({ features });
+      this.layer.patches.colorLayer = new itowns.ColorLayer(
+        this.layer.patches.name,
+        this.layer.patches.config,
       );
-      this.view.addLayer(this.layer.retouches.colorLayer);
-      itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Retouches', 3);
+      this.view.addLayer(this.layer.patches.colorLayer);
+      itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Patches', 3);
     }
 
     this.view.notifyChange();
@@ -155,7 +155,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       } else {
         this.message = "polygon: out of OPI's bounds";
       }
@@ -376,7 +376,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -398,7 +398,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -421,7 +421,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -444,7 +444,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph', 'retouches']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* global setupLoadingScreen, GuiTools */
 import * as itowns from 'itowns';
-import Saisie from './Saisie';
+import Saisie, { fetcher, parser } from './Saisie';
 
 // Global itowns pour GuiTools -> peut être améliorer
 global.itowns = itowns;
@@ -15,13 +15,13 @@ console.log('serverAPI:', serverAPI, 'portAPI:', portAPI);
 
 const apiUrl = `http://${serverAPI}:${portAPI}`;
 
-function fetcher(url) {
-  return itowns.Fetcher.json(url);
-}
+// export function fetcher(url) {
+//   return itowns.Fetcher.json(url);
+// }
 
-function parser(geojson, option) {
-  return itowns.GeoJsonParser.parse(geojson, option);
-}
+// function parser(geojson, option) {
+//   return itowns.GeoJsonParser.parse(geojson, option);
+// }
 
 itowns.Fetcher.json(`${apiUrl}/version`)
   .then((obj) => {
@@ -123,7 +123,7 @@ async function main() {
       ortho: 1,
       graph: 0.2,
       opi: 0.5,
-      retouches: 0.75,
+      patches: 0.75,
     };
 
     const layer = {};
@@ -156,12 +156,12 @@ async function main() {
     itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Graph', 2);
     // Et ouvrir l'onglet "Color Layers" par defaut ?
 
-    // Couche Retouches
-    layer.retouches = {
-      name: 'Retouches',
+    // Couche Patches
+    layer.patches = {
+      name: 'Patches',
       config: {
         transparent: true,
-        opacity: 0.62,
+        opacity: opacity.patches,
       },
       optionsGeoJsonParser: {
         in: {
@@ -179,25 +179,22 @@ async function main() {
 
     const json = await fetcher(`${apiUrl}/json/activePatchs`);
 
-    const features = await parser(JSON.stringify(json), layer.retouches.optionsGeoJsonParser);
+    const features = await parser(JSON.stringify(json), layer.patches.optionsGeoJsonParser);
 
-    layer.retouches.config.source = new itowns.FileSource({ features });
-    layer.retouches.config.style = new itowns.Style({
-      fill: {
-        color: 'orange',
-        opacity: 0.5,
-      },
+    layer.patches.config.source = new itowns.FileSource({ features });
+    layer.patches.config.style = new itowns.Style({
       stroke: {
-        color: 'IndianRed',
+        color: 'Red',
+        width: 2,
       },
     });
 
-    layer.retouches.colorLayer = new itowns.ColorLayer(
-      layer.retouches.name,
-      layer.retouches.config,
+    layer.patches.colorLayer = new itowns.ColorLayer(
+      layer.patches.name,
+      layer.patches.config,
     );
-    view.addLayer(layer.retouches.colorLayer);
-    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Retouches', 3);
+    view.addLayer(layer.patches.colorLayer);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Patches', 3);
 
     // Request redraw
     console.log('redraw');

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -153,6 +153,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   saisie.controllers.undo = menuGlobe.gui.add(saisie, 'undo');
   saisie.controllers.redo = menuGlobe.gui.add(saisie, 'redo');
   if (process.env.NODE_ENV === 'development') saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
+  if (process.env.NODE_ENV === 'development') saisie.controllers.save = menuGlobe.gui.add(saisie, 'save');
   saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
   saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
 

--- a/itowns/package.json
+++ b/itowns/package.json
@@ -13,9 +13,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "itowns": "^2.30.0",
-    "proj4": "^2.7.0",
-    "three": "^0.125.0"
+    "itowns": "^2.32.0",
+    "proj4": "^2.7.2",
+    "three": "^0.127.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/regress/patch.js
+++ b/regress/patch.js
@@ -130,6 +130,7 @@ describe('Patch', () => {
         });
     });
   });
+
   describe('PUT /patchs/clear', () => {
     it("should return a warning (code 401): 'unauthorized'", (done) => {
       chai.request(server)
@@ -197,6 +198,89 @@ describe('Patch', () => {
           should.not.exist(err);
           res.should.have.status(201);
           res.text.should.equal('nothing to clear');
+          done();
+        });
+    });
+  });
+
+  describe('PUT /patchs/save', () => {
+    it("should return a warning (code 401): 'unauthorized'", (done) => {
+      chai.request(server)
+        .put('/patchs/save')
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(401);
+          res.text.should.equal('unauthorized');
+          done();
+        });
+    });
+    it("should return 'save: all active patches saved'", (done) => {
+      // first add a patch
+      chai.request(server)
+        .post('/patch')
+        .send({
+          type: 'FeatureCollection',
+          crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2154' } },
+          features: [
+            {
+              type: 'Feature',
+              properties: { color: [58, 149, 47], cliche: '19FD5606Ax00020_16371' },
+              geometry: { type: 'Polygon', coordinates: [[[230748, 6759646], [230752, 6759646], [230752, 6759644], [230748, 6759644], [230748, 6759646]]] },
+            }],
+        })
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(200);
+          const resJson = JSON.parse(res.text);
+          resJson.should.be.a('array');
+
+          // and a second patch
+          chai.request(server)
+            .post('/patch')
+            .send({
+              type: 'FeatureCollection',
+              crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2154' } },
+              features: [
+                {
+                  type: 'Feature',
+                  properties: { color: [58, 149, 47], cliche: '19FD5606Ax00020_16371' },
+                  geometry: { type: 'Polygon', coordinates: [[[230748, 6759646], [230752, 6759646], [230752, 6759644], [230748, 6759644], [230748, 6759646]]] },
+                }],
+            })
+            .end((err1, res1) => {
+              should.not.exist(err1);
+              res1.should.have.status(200);
+              const res1Json = JSON.parse(res1.text);
+              res1Json.should.be.a('array');
+
+              // then undo it
+              chai.request(server)
+                .put('/patch/undo')
+                .end((err2, res2) => {
+                  should.not.exist(err2);
+                  res2.should.have.status(200);
+                  res2.text.should.equal('undo: patch 2 canceled');
+
+                  // then save
+                  chai.request(server)
+                    .put('/patchs/save?test=true')
+                    .end((err3, res3) => {
+                      should.not.exist(err3);
+                      res3.should.have.status(200);
+                      res3.text.should.equal('save: all active patches saved');
+                      done();
+                    });
+                });
+            });
+        });
+    });
+    it("should return a warning (code 201): 'nothing to save'", (done) => {
+      chai.request(server)
+        .put('/patchs/save?test=true')
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(201);
+          res.text.should.equal('nothing to save');
           done();
         });
     });

--- a/rok4.js
+++ b/rok4.js
@@ -2,6 +2,7 @@ const path = require('path');
 const debug = require('debug')('rok4');
 
 function getTileRoot(X, Y, Z, pathDepth) {
+  debug('~~~getTileRoot');
   debug(X, Y, Z, pathDepth);
   const strX = Math.trunc(X).toString(36).padStart(pathDepth + 1, 0).toUpperCase();
   const strY = Math.trunc(Y).toString(36).padStart(pathDepth + 1, 0).toUpperCase();
@@ -11,9 +12,10 @@ function getTileRoot(X, Y, Z, pathDepth) {
     url = path.join(url, strX[i] + strY[i]);
   }
   debug(url);
-  url = path.join(url, strX[pathDepth] + strY[pathDepth]);
-  debug(url);
-  return url;
+  return {
+    dirPath: url,
+    fileName: strX[pathDepth] + strY[pathDepth],
+  };
 }
 
 exports.getTileRoot = getTileRoot;

--- a/routes/file.js
+++ b/routes/file.js
@@ -13,7 +13,7 @@ const parentDir = `${global.dir_cache}`;
 router.get('/json/:typefile', [
   param('typefile')
     .exists().withMessage(createErrMsg.missingParameter('typefile'))
-    .isIn(['overviews', 'test'])
+    .isIn(['overviews', 'activePatchs', 'test'])
     .withMessage(createErrMsg.invalidParameter('typefile')),
 ], validateParams,
 (req, res) => {

--- a/routes/graph.js
+++ b/routes/graph.js
@@ -43,8 +43,8 @@ router.get('/graph', [
   const Ty = Math.floor(Py / overviews.tileSize.height);
   const I = Math.floor(Px - Tx * overviews.tileSize.width);
   const J = Math.floor(Py - Ty * overviews.tileSize.height);
-
-  const url = path.join(global.dir_cache, 'graph', `${rok4.getTileRoot(Tx, Ty, lvlMax, overviews.pathDepth)}.png`);
+  const tileRoot = rok4.getTileRoot(Tx, Ty, lvlMax, overviews.pathDepth);
+  const url = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}.png`);
   debug(url);
   // _graph.png`;
   if (!fs.existsSync(url)) {

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -404,6 +404,29 @@ router.put('/patchs/clear', [], (req, res) => {
     });
   });
 
+  req.app.unactivePatchs.features.forEach((feature) => {
+    // trouver la liste des tuiles concernées par ces patchs
+    const { tiles } = feature.properties;
+    debug(tiles.size, 'tuiles impactées');
+    // pour chaque tuile, on efface les images du redo
+    tiles.forEach((tile) => {
+      const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
+
+      const graphDir = path.join(global.dir_cache, 'graph', tileRoot.dirPath);
+      const orthoDir = path.join(global.dir_cache, 'ortho', tileRoot.dirPath);
+
+      const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes('_') && !filename.endsWith('orig.png')));
+      // suppression des images intermediaires
+      arrayLinkGraph.forEach((file) => fs.unlinkSync(
+        path.join(graphDir, file),
+      ));
+      const arrayLinkOrtho = fs.readdirSync(orthoDir).filter((filename) => (filename.includes('_') && !filename.endsWith('orig.png')));
+      // suppression des images intermediaires
+      arrayLinkOrtho.forEach((file) => fs.unlinkSync(
+        path.join(orthoDir, file),
+      ));
+    });
+  });
   req.app.activePatchs.features = [];
   req.app.unactivePatchs.features = [];
   fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(req.app.activePatchs, null, 4));

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -139,8 +139,8 @@ router.post('/patch', encapBody.bind({ keyName: 'geoJSON' }), [
         return;
       }
       /* eslint-disable no-param-reassign */
-      patch.urlGraphOutput = path.join(global.dir_cache, 'graph', `${patch.tileRoot}_${newPatchId}.png`);
-      patch.urlOrthoOutput = path.join(global.dir_cache, 'ortho', `${patch.tileRoot}_${newPatchId}.png`);
+      patch.urlGraphOutput = path.join(global.dir_cache, 'graph', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}_${newPatchId}.png`);
+      patch.urlOrthoOutput = path.join(global.dir_cache, 'ortho', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}_${newPatchId}.png`);
       /* eslint-enable no-param-reassign */
       tilesModified.push(patch.tile);
       promises.push(pool.exec(
@@ -158,7 +158,7 @@ router.post('/patch', encapBody.bind({ keyName: 'geoJSON' }), [
         if (patch === null) {
           return;
         }
-        const urlHistory = path.join(global.dir_cache, 'opi', `${patch.tileRoot}_history.packo`);
+        const urlHistory = path.join(global.dir_cache, 'opi', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}_history.packo`);
         if (fs.lstatSync(patch.urlGraph).nlink > 1) {
           const history = `${fs.readFileSync(`${urlHistory}`)};${newPatchId}`;
           debug(patch.urlGraph);
@@ -169,8 +169,8 @@ router.post('/patch', encapBody.bind({ keyName: 'geoJSON' }), [
         } else {
           const history = `orig;${newPatchId}`;
           fs.writeFileSync(`${urlHistory}`, history);
-          const urlGraphOrig = path.join(global.dir_cache, 'graph', `${patch.tileRoot}_orig.png`);
-          const urlOrthoOrig = path.join(global.dir_cache, 'ortho', `${patch.tileRoot}_orig.png`);
+          const urlGraphOrig = path.join(global.dir_cache, 'graph', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}_orig.png`);
+          const urlOrthoOrig = path.join(global.dir_cache, 'ortho', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}_orig.png`);
           fs.renameSync(patch.urlGraph, urlGraphOrig);
           fs.renameSync(patch.urlOrtho, urlOrthoOrig);
         }
@@ -241,7 +241,7 @@ router.put('/patch/undo', [], (req, res) => {
   tiles.forEach((tile) => {
     const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
     // on récupère l'historique de cette tuile
-    const urlHistory = path.join(global.dir_cache, 'opi', `${tileRoot}_history.packo`);
+    const urlHistory = path.join(global.dir_cache, 'opi', tileRoot.dirPath, `${tileRoot.fileName}_history.packo`);
     const history = fs.readFileSync(`${urlHistory}`).toString().split(';');
     // on vérifie que le lastPatchId est bien le dernier sur cette tuile
     if (`${history[history.length - 1]}` !== `${lastPatchId}`) {
@@ -261,10 +261,10 @@ router.put('/patch/undo', [], (req, res) => {
     debug(` tuile ${tile.z}/${tile.y}/${tile.x} : version ${idSelected} selectionnée`);
     // debug(' version selectionnée pour la tuile :', idSelected);
     // modifier les liens symboliques pour pointer sur ce numéro de version
-    const urlGraph = path.join(global.dir_cache, 'graph', `${tileRoot}.png`);
-    const urlOrtho = path.join(global.dir_cache, 'ortho', `${tileRoot}.png`);
-    const urlGraphSelected = path.join(global.dir_cache, 'graph', `${tileRoot}_${idSelected}.png`);
-    const urlOrthoSelected = path.join(global.dir_cache, 'ortho', `${tileRoot}_${idSelected}.png`);
+    const urlGraph = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}.png`);
+    const urlOrtho = path.join(global.dir_cache, 'ortho', tileRoot.dirPath, `${tileRoot.fileName}.png`);
+    const urlGraphSelected = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}_${idSelected}.png`);
+    const urlOrthoSelected = path.join(global.dir_cache, 'ortho', tileRoot.dirPath, `${tileRoot.fileName}_${idSelected}.png`);
     // on supprime l'ancien lien
     fs.unlinkSync(urlGraph);
     fs.unlinkSync(urlOrtho);
@@ -316,15 +316,15 @@ router.put('/patch/redo', [], (req, res) => {
   tiles.forEach((tile) => {
     const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
     // on met a jour l'historique
-    const urlHistory = path.join(global.dir_cache, 'opi', `${tileRoot}_history.packo`);
+    const urlHistory = path.join(global.dir_cache, 'opi', tileRoot.dirPath, `${tileRoot.fileName}_history.packo`);
     const history = `${fs.readFileSync(`${urlHistory}`)};${patchIdRedo}`;
     fs.writeFileSync(`${urlHistory}`, history);
     // on verifie si la tuile a été effectivement modifiée par ce patch
-    const urlGraphSelected = path.join(global.dir_cache, 'graph', `${tileRoot}_${patchIdRedo}.png`);
-    const urlOrthoSelected = path.join(global.dir_cache, 'ortho', `${tileRoot}_${patchIdRedo}.png`);
+    const urlGraphSelected = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}_${patchIdRedo}.png`);
+    const urlOrthoSelected = path.join(global.dir_cache, 'ortho', tileRoot.dirPath, `${tileRoot.fileName}_${patchIdRedo}.png`);
     // modifier les liens symboliques pour pointer sur ce numéro de version
-    const urlGraph = path.join(global.dir_cache, 'graph', `${tileRoot}.png`);
-    const urlOrtho = path.join(global.dir_cache, 'ortho', `${tileRoot}.png`);
+    const urlGraph = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}.png`);
+    const urlOrtho = path.join(global.dir_cache, 'ortho', tileRoot.dirPath, `${tileRoot.fileName}.png`);
     // on supprime l'ancien lien
     fs.unlinkSync(urlGraph);
     fs.unlinkSync(urlOrtho);
@@ -368,11 +368,12 @@ router.put('/patchs/clear', [], (req, res) => {
     // pour chaque tuile, on retablit la version orig
     tiles.forEach((tile) => {
       const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
-      const urlGraphSelected = path.join(global.dir_cache, 'graph', `${tileRoot}_orig.png`);
-      const urlOrthoSelected = path.join(global.dir_cache, 'ortho', `${tileRoot}_orig.png`);
 
-      const graphDir = path.join(global.dir_cache, 'graph', path.dirname(tileRoot));
-      const orthoDir = path.join(global.dir_cache, 'ortho', path.dirname(tileRoot));
+      const graphDir = path.join(global.dir_cache, 'graph', tileRoot.dirPath);
+      const orthoDir = path.join(global.dir_cache, 'ortho', tileRoot.dirPath);
+
+      const urlGraphSelected = path.join(graphDir, `${tileRoot.fileName}_orig.png`);
+      const urlOrthoSelected = path.join(orthoDir, `${tileRoot.fileName}_orig.png`);
 
       const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes('_') && !filename.endsWith('orig.png')));
       // suppression des images intermediaires
@@ -386,12 +387,12 @@ router.put('/patchs/clear', [], (req, res) => {
       ));
 
       // remise à zéro de l'historique de la tuile
-      const urlHistory = path.join(global.dir_cache, 'opi', `${tileRoot}_history.packo`);
+      const urlHistory = path.join(global.dir_cache, 'opi', tileRoot.dirPath, `${tileRoot.fileName}_history.packo`);
       fs.writeFileSync(`${urlHistory}`, 'orig');
 
       // modifier les liens symboliques pour pointer sur ce numéro de version
-      const urlGraph = path.join(global.dir_cache, 'graph', `${tileRoot}.png`);
-      const urlOrtho = path.join(global.dir_cache, 'ortho', `${tileRoot}.png`);
+      const urlGraph = path.join(graphDir, `${tileRoot.fileName}.png`);
+      const urlOrtho = path.join(orthoDir, `${tileRoot.fileName}.png`);
       // on supprime l'ancien lien
       fs.unlinkSync(urlGraph);
       fs.unlinkSync(urlOrtho);

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -375,6 +375,7 @@ router.put('/patchs/clear', [], (req, res) => {
       const urlGraphSelected = path.join(graphDir, `${tileRoot.fileName}_orig.png`);
       const urlOrthoSelected = path.join(orthoDir, `${tileRoot.fileName}_orig.png`);
 
+      // include('_') suffit car on veut tout supprimer (meme sur les autres tuiles)
       const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes('_') && !filename.endsWith('orig.png')));
       // suppression des images intermediaires
       arrayLinkGraph.forEach((file) => fs.unlinkSync(
@@ -435,6 +436,111 @@ router.put('/patchs/clear', [], (req, res) => {
   debug(' features in unactivePatchs:', req.app.unactivePatchs.features.length);
   debug('fin du clear');
   res.status(200).send('clear: all patches deleted');
+});
+
+router.put('/patchs/save', [], (req, res) => {
+  debug('~~~PUT patchs/save');
+  if (!(process.env.NODE_ENV === 'development' || req.query.test === 'true')) {
+    debug('unauthorized');
+    res.status(401).send('unauthorized');
+    return;
+  }
+  // pour chaque patch de req.app.activePatchs.features
+  if (req.app.activePatchs.features.length === 0) {
+    debug('nothing to save');
+    res.status(201).send('nothing to save');
+    return;
+  }
+  const { overviews } = req.app;
+  const { features } = req.app.activePatchs;
+
+  const lastPatchId = req.app.activePatchs.features[req.app.activePatchs.features.length - 1]
+    .properties.patchId;
+  debug('lastPatchId:', lastPatchId);
+
+  features.forEach((feature) => {
+    // trouver la liste des tuiles concernées par ces patchs
+    const { tiles } = feature.properties;
+    debug(tiles.length, 'tuiles impactées');
+    // pour chaque tuile, on écrase la version orig
+    tiles.forEach((tile) => {
+      const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
+      // on récupère l'historique de cette tuile
+      const urlHistory = path.join(global.dir_cache, 'opi', tileRoot.dirPath, `${tileRoot.fileName}_history.packo`);
+      const history = fs.readFileSync(`${urlHistory}`).toString().split(';');
+
+      debug('____');
+      debug(tile);
+      debug(history);
+
+      // on récupère la version à restaurer
+      const idSelected = history[history.length - 1];
+      debug('  version sauvegardée pour la tuile :', idSelected);
+
+      // on supprime chaque image sauf l'image active (pour graph et ortho)
+      const graphDir = path.join(global.dir_cache, 'graph', tileRoot.dirPath);
+      const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`)));
+      arrayLinkGraph.forEach((file) => {
+        if (file.split('_')[1] !== `${idSelected}.png`) {
+          debug('supp', file);
+          fs.unlinkSync(path.join(graphDir, file));
+        }
+      });
+      const orthoDir = path.join(global.dir_cache, 'ortho', tileRoot.dirPath);
+      const arrayLinkOrtho = fs.readdirSync(orthoDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`)));
+      arrayLinkOrtho.forEach((file) => {
+        if (file.split('_')[1] !== `${idSelected}.png`) {
+          debug('supp', file);
+          fs.unlinkSync(path.join(orthoDir, file));
+        }
+      });
+      // on renomme l'image active en _orig
+      fs.renameSync(
+        path.join(graphDir, `${tileRoot.fileName}_${idSelected}.png`),
+        path.join(graphDir, `${tileRoot.fileName}_orig.png`),
+      );
+      fs.renameSync(
+        path.join(orthoDir, `${tileRoot.fileName}_${idSelected}.png`),
+        path.join(orthoDir, `${tileRoot.fileName}_orig.png`),
+      );
+      // remise à zéro de l'historique de la tuile
+      fs.writeFileSync(`${urlHistory}`, 'orig');
+    });
+  });
+
+  req.app.unactivePatchs.features.forEach((feature) => {
+    // trouver la liste des tuiles concernées par ces patchs
+    const { tiles } = feature.properties;
+    debug(tiles.size, 'tuiles impactées');
+    // pour chaque tuile, on efface les images du redo
+    tiles.forEach((tile) => {
+      const tileRoot = rok4.getTileRoot(tile.x, tile.y, tile.z, overviews.pathDepth);
+
+      const graphDir = path.join(global.dir_cache, 'graph', tileRoot.dirPath);
+      const orthoDir = path.join(global.dir_cache, 'ortho', tileRoot.dirPath);
+
+      const arrayLinkGraph = fs.readdirSync(graphDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`) && !filename.endsWith('orig.png')));
+      // suppression des images intermediaires
+      arrayLinkGraph.forEach((file) => fs.unlinkSync(
+        path.join(graphDir, file),
+      ));
+      const arrayLinkOrtho = fs.readdirSync(orthoDir).filter((filename) => (filename.includes(`${tileRoot.fileName}_`) && !filename.endsWith('orig.png')));
+      // suppression des images intermediaires
+      arrayLinkOrtho.forEach((file) => fs.unlinkSync(
+        path.join(orthoDir, file),
+      ));
+    });
+  });
+  const date = new Date(Date.now()).toISOString().replace(/-|T|:/g, '').substr(0, 14);
+  fs.writeFileSync(path.join(global.dir_cache, `save_${date}Z.json`), JSON.stringify(req.app.activePatchs, null, 4));
+  req.app.activePatchs.features = [];
+  req.app.unactivePatchs.features = [];
+  fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(req.app.activePatchs, null, 4));
+  fs.writeFileSync(path.join(global.dir_cache, 'unactivePatchs.json'), JSON.stringify(req.app.unactivePatchs, null, 4));
+  debug('features in activePatchs:', req.app.activePatchs.features.length);
+  debug('features in unactivePatchs:', req.app.unactivePatchs.features.length);
+  debug('fin du save');
+  res.status(200).send('save: all active patches saved');
 });
 
 module.exports = router;

--- a/routes/wmts.js
+++ b/routes/wmts.js
@@ -274,7 +274,7 @@ router.get('/wmts', [
       mime = Jimp.MIME_JPEG; // "image/jpeg"
     }
     const tileRoot = rok4.getTileRoot(TILECOL, TILEROW, TILEMATRIX, overviews.pathDepth);
-    let url = path.join(global.dir_cache, layerName, tileRoot);
+    let url = path.join(global.dir_cache, layerName, tileRoot.dirPath, tileRoot.fileName);
     if (LAYER === 'opi') {
       if (!Name) {
         url += `_${overviews.list_OPI[0]}`;
@@ -307,7 +307,7 @@ router.get('/wmts', [
     debug('~~~GetFeatureInfo');
     debugFeatureInfo(LAYER, TILEMATRIX, TILEROW, TILECOL, I, J);
     const tileRoot = rok4.getTileRoot(TILECOL, TILEROW, TILEMATRIX, overviews.pathDepth);
-    const url = `${path.join(global.dir_cache, 'graph', tileRoot)}.png`;
+    const url = path.join(global.dir_cache, 'graph', tileRoot.dirPath, `${tileRoot.fileName}.png`);
 
     if (!fs.existsSync(url)) {
       const erreur = new Error();

--- a/routes/worker.js
+++ b/routes/worker.js
@@ -64,13 +64,15 @@ function createPatch(tile, geoJson, overviews, dirCache) {
   }
 
   const patch = { tile, mask, color: geoJson.features[0].properties.color };
-  patch.tileRoot = rok4Process.getTileRoot(patch.tile.x,
+  patch.tileRoot = rok4Process.getTileRoot(
+    patch.tile.x,
     patch.tile.y,
     patch.tile.z,
-    overviews.pathDepth);
-  patch.urlGraph = pathProcess.join(dirCache, 'graph', `${patch.tileRoot}.png`);
-  patch.urlOrtho = pathProcess.join(dirCache, 'ortho', `${patch.tileRoot}.png`);
-  patch.urlOpi = pathProcess.join(dirCache, 'opi', `${patch.tileRoot}_${geoJson.features[0].properties.cliche}.png`);
+    overviews.pathDepth,
+  );
+  patch.urlGraph = pathProcess.join(dirCache, 'graph', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}.png`);
+  patch.urlOrtho = pathProcess.join(dirCache, 'ortho', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}.png`);
+  patch.urlOpi = pathProcess.join(dirCache, 'opi', patch.tileRoot.dirPath, `${patch.tileRoot.fileName}_${geoJson.features[0].properties.cliche}.png`);
   const checkGraph = fsProcess.promises.access(patch.urlGraph, fsProcess.constants.F_OK);
   const checkOrtho = fsProcess.promises.access(patch.urlOrtho, fsProcess.constants.F_OK);
   const checkOpi = fsProcess.promises.access(patch.urlOpi, fsProcess.constants.F_OK);

--- a/serveur.js
+++ b/serveur.js
@@ -55,7 +55,7 @@ try {
   app.overviews = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'overviews.json')));
 
   try {
-    app.activePatchs = JSON.parse(fs.readFileSync(`${global.dir_cache}/activePatchs.json`));
+    app.activePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'activePatchs.json')));
   } catch (err) {
     app.activePatchs = {
       type: 'FeatureCollection',
@@ -68,11 +68,11 @@ try {
       },
       features: [],
     };
-    fs.writeFileSync(`${global.dir_cache}/activePatchs.json`, JSON.stringify(app.activePatchs));
+    fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(app.activePatchs, null, 4));
   }
 
   try {
-    app.unactivePatchs = JSON.parse(fs.readFileSync(`${global.dir_cache}/unactivePatchs.json`));
+    app.unactivePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'unactivePatchs.json')));
   } catch (err) {
     app.unactivePatchs = {
       type: 'FeatureCollection',
@@ -85,7 +85,7 @@ try {
       },
       features: [],
     };
-    fs.writeFileSync(`${global.dir_cache}/unactivePatchs.json`, JSON.stringify(app.unactivePatchs));
+    fs.writeFileSync(path.join(global.dir_cache, 'unactivePatchs.json'), JSON.stringify(app.unactivePatchs, null, 4));
   }
 
   app.use(cors());


### PR DESCRIPTION
[Précision polygones affichés : en attente Fix itowns 2.33 ]

Cette PR ajoute deux fonctionnalités :

- l'ajout d'une couche vectorielle 'retouches' permettant la visualisation de l'ensemble des patchs actifs (à tout instants)
- un bouton 'save' permettant la sauvegarde (et la pérennisation) de tous les patchs actifs, un fichier save_'date'.json est crée contenant les polygones de retouches sauvegardés.
