### PR TITLE
[cache.py] Recalcul ortho and graph (après un bug lors de cette même phase) => #123

### DIFF
--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -185,21 +185,24 @@ def generate(update):
     print(" Découpage")
 
     cpu_dispo = multiprocessing.cpu_count()
-    if (cpu_dispo > 2):
-        pool = multiprocessing.Pool(cpu_dispo - 1)
-        pool.map(cache.cut_image_1arg, args_cut_image)
 
-        pool.close()
-        pool.join()
-    else:
-        for arg in args_cut_image:
-            cache.cut_image_1arg(arg)
+    if not args.recalcul:
 
-    with open(args.cache + '/cache_mtd.json', 'w') as outfile:
-        json.dump(color_dict, outfile)
+        if (cpu_dispo > 2):
+            pool = multiprocessing.Pool(cpu_dispo - 1)
+            pool.map(cache.cut_image_1arg, args_cut_image)
 
-    with open(args.cache + '/overviews.json', 'w') as outfile:
-        json.dump(overviews_dict, outfile)
+            pool.close()
+            pool.join()
+        else:
+            for arg in args_cut_image:
+                cache.cut_image_1arg(arg)
+
+        with open(args.cache + '/cache_mtd.json', 'w') as outfile:
+            json.dump(color_dict, outfile)
+
+        with open(args.cache + '/overviews.json', 'w') as outfile:
+            json.dump(overviews_dict, outfile)
 
     tps1 = time.perf_counter()
     if args.verbose > 0:
@@ -219,7 +222,8 @@ def generate(update):
                                                                  'nbBands': NB_BANDS,
                                                                  'spatialRef': spatial_ref_wkt
                                                              },
-                                                             change)
+                                                             change,
+                                                             args.recalcul > 1)
 
     tps2 = time.perf_counter()
     if args.verbose > 0:

--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -46,6 +46,11 @@ def read_args(update):
                             " (e.g., 15 19)",
                             type=int,
                             nargs='+')
+    if update is True:
+        parser.add_argument("-r", "--recalcul",
+                            help="recalcul apres bug",
+                            type=int,
+                            default=0)
     parser.add_argument("-g", "--geopackage",
                         help="base GeoPackage (default: "")",
                         type=str,
@@ -78,6 +83,8 @@ def read_args(update):
                 lvl_max = args.level[0]
                 args.level[0] = args.level[1]
                 args.level[1] = lvl_max
+
+        args.recalcul = 0
     else:
         if not os.path.isdir(args.cache):
             raise SystemExit("Cache '" + args.cache + "' doesn't exist.")
@@ -172,7 +179,8 @@ def generate(update):
                                                                   'nbBands': NB_BANDS,
                                                                   'spatialRef': spatial_ref_wkt
                                                               },
-                                                              args.verbose)
+                                                              args.verbose,
+                                                              args.recalcul)
 
     print(" Découpage")
 

--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -185,6 +185,9 @@ def generate(update):
     print(" Découpage")
 
     cpu_dispo = multiprocessing.cpu_count()
+    #########################
+    cpu_dispo = 6
+    #########################
 
     if not args.recalcul:
 

--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -177,7 +177,6 @@ def generate(update):
     print(" Découpage")
 
     cpu_dispo = multiprocessing.cpu_count()
-
     if (cpu_dispo > 2):
         pool = multiprocessing.Pool(cpu_dispo - 1)
         pool.map(cache.cut_image_1arg, args_cut_image)
@@ -226,11 +225,18 @@ def generate(update):
     print('   |', end='', flush=True)
 
     if (cpu_dispo > 2):
-        pool = multiprocessing.Pool(cpu_dispo - 1)
-        pool.map(cache.create_ortho_and_graph_1arg, args_create_ortho_and_graph)
+        step = cpu_dispo * 100
+        for thread in range(0, len(args_create_ortho_and_graph), step):
+            argument = args_create_ortho_and_graph[thread:thread + step]
+            pool = multiprocessing.Pool(cpu_dispo - 1)
+            pool.map(cache.create_ortho_and_graph_1arg, argument)
 
-        pool.close()
-        pool.join()
+            pool.close()
+            pool.join()
+
+            with open(args.cache + '/log.txt', 'a') as outfile:
+                print(str(thread) + " to " + str(thread + step - 1) + ": DONE", file=outfile)
+
     else:
         for arg in args_create_ortho_and_graph:
             cache.create_ortho_and_graph_1arg(arg)

--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -127,21 +127,20 @@ def new_color(image, color_dict):
     return color
 
 
-def prep_tiling(list_filename, dir_cache, overviews, color_dict, gdal_option, verbose):
+def prep_tiling(list_filename, dir_cache, overviews, color_dict, gdal_option, verbose, recalcul):
     """Preparation for tiling images according to overviews file"""
     opi_already_calculated = []
     args_cut_image = []
-
     change = {}
 
     for filename in list_filename:
+        print('  image :', filename)
+
         opi = Path(filename).stem
-        if opi in overviews['list_OPI'].keys():
-            # OPI déjà traitée
+        if not recalcul and opi in overviews['list_OPI'].keys():
+            print('    -> déjà calculée')
             opi_already_calculated.append(opi)
         else:
-            print('  image :', filename)
-
             args_cut_image.append({
                 'opi': {
                     'path': filename,


### PR DESCRIPTION
Objectifs:

- permettre le recalcul d'ortho et de graph pour des OPI ayant déjà était découpées (Bug lors d'une exécution précédente)

Modification : 
- ajout d'une option --recalcul (applicable seulement en mode update)
    - 0 ou absent : pas d'effet
    - = 1 : recalcul ortho et graph pour des OPI déjà traitées
    - \>1 : recalcul ortho et graph seulement si celle-ci n'existe pas déjà (cas du bug bande 13)
- lors du calcul des ortho et graph : 
  - regroupement des thread par paquet de 100*cpu 
  - création d'un fichier log pour suivre l'évolution de manière chiffrée de ces regroupement