### PR TITLE
[cache] Re-traitement OPI lors d'un update

### DIFF
--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -47,8 +47,15 @@ def read_args(update):
                             " (e.g., 15 19)",
                             type=int,
                             nargs='+')
+    if update is True:
+        parser.add_argument("-r", "--reprocessing",
+                            help="reprocessing of OPI already processed"
+                            " (default: 0, existing OPIs are not reprocessed)",
+                            type=int,
+                            default=0)
     parser.add_argument("-g", "--geopackage",
-                        help="base GeoPackage (default: "")",
+                        help="in case the graph base is a GeoPackage"
+                        " and not a postgres base define through env variables",
                         type=str,
                         default="")
     parser.add_argument("-t", "--table",
@@ -83,6 +90,8 @@ def read_args(update):
                 lvl_max = args.level[0]
                 args.level[0] = args.level[1]
                 args.level[1] = lvl_max
+
+        args.reprocessing = 0
     else:
         if not os.path.isdir(args.cache):
             raise SystemExit("Cache '" + args.cache + "' doesn't exist.")
@@ -178,7 +187,8 @@ def generate(update):
                                                                   'nbBands': NB_BANDS,
                                                                   'spatialRef': spatial_ref_wkt
                                                               },
-                                                              args.verbose)
+                                                              args.verbose,
+                                                              args.reprocessing)
 
     print(" Découpage")
 

--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -229,15 +229,22 @@ def generate(update):
     cache.progress_bar(50, nb_tiles, args_create_ortho_and_graph)
     print('   |', end='', flush=True)
 
-    if (cpu_util > 1):
-        pool = multiprocessing.Pool(cpu_util)
-        pool.map(cache.create_ortho_and_graph_1arg, args_create_ortho_and_graph)
+    batchSize = cpu_util * 100
+    for numBatch in range(0, len(args_create_ortho_and_graph), batchSize):
+        argument = args_create_ortho_and_graph[numBatch:numBatch + batchSize]
+        if (cpu_util > 1):
+            pool = multiprocessing.Pool(cpu_util)
+            pool.map(cache.create_ortho_and_graph_1arg, argument)
 
-        pool.close()
-        pool.join()
-    else:
-        for arg in args_create_ortho_and_graph:
-            cache.create_ortho_and_graph_1arg(arg)
+            pool.close()
+            pool.join()
+        else:
+            for arg in argument:
+                cache.create_ortho_and_graph_1arg(arg)
+
+        with open(args.cache + '/log.txt', 'a') as outfile:
+            print(str(numBatch) + " to " + str(numBatch + batchSize - 1) + ": DONE",
+                  file=outfile)
 
     print("|")
     tps4 = time.perf_counter()

--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -132,21 +132,19 @@ def new_color(image, color_dict):
     return [int(color_str[0]), int(color_str[1]), int(color_str[2])]
 
 
-def prep_tiling(list_filename, dir_cache, overviews, color_dict, gdal_option, verbose):
+def prep_tiling(list_filename, dir_cache, overviews, color_dict, gdal_option, verbose, reprocess):
     """Preparation for tiling images according to overviews file"""
     opi_already_calculated = []
     args_cut_image = []
-
     change = {}
 
     for filename in list_filename:
+        print('  image :', filename)
         opi = Path(filename).stem
-        if opi in overviews['list_OPI'].keys():
-            # OPI déjà traitée
+        if not reprocess and opi in overviews['list_OPI'].keys():
+            print('   -> déjà calculée')
             opi_already_calculated.append(opi)
         else:
-            print('  image :', filename)
-
             args_cut_image.append({
                 'opi': {
                     'path': filename,


### PR DESCRIPTION
Objectif : 
- Pouvoir re-traiter en intégralité (découpage et calcul ortho/graph) d'une ou plusieurs OPIs déjà traitées.

Modifications : 
- meilleure gestion du nombre de cpu utilisé : ajout d'une option --processors (par défaut cpu_count()-1)
- ajout d'une option --reprocessing (pris en compte seulement en mode update)
- lors du calcul des ortho et graph :
  - regroupement des thread par paquet de 100*cpu_util
  - création d'un fichier log pour suivre l'évolution de manière chiffrée de ces regroupement
- ajout d'un block try/except de l'ensemble du processus de traitement
