### PR TITLE
[cache] Warp OPI sous ech et translate

### DIFF
--- a/regress/patch.js
+++ b/regress/patch.js
@@ -130,19 +130,8 @@ describe('Patch', () => {
         });
     });
   });
-  describe('PUT /patchs/clear', () => {
-    it("should return a warning (code 401): 'unauthorized'", (done) => {
-      chai.request(server)
-        .put('/patchs/clear')
-        .end((err, res) => {
-          should.not.exist(err);
-          res.should.have.status(401);
-          res.text.should.equal('unauthorized');
-          done();
-        });
-    });
-    it("should return 'clear: all patches deleted'", (done) => {
-      // Ajout d'un nouveau patch
+  describe('prep for clear', () => {
+    it('Add a new patch', (done) => {
       chai.request(server)
         .post('/patch')
         .send({
@@ -160,36 +149,42 @@ describe('Patch', () => {
           res.should.have.status(200);
           const resJson = JSON.parse(res.text);
           resJson.should.be.a('array');
-
-          // Avant de l'annuler
-          chai.request(server)
-            .put('/patch/undo')
-            .end((err1, res1) => {
-              should.not.exist(err1);
-              res1.should.have.status(200);
-              res1.text.should.equal('undo: patch 2 canceled');
-
-              // Pour faire le clear
-              chai.request(server)
-                .put('/patchs/clear?test=true')
-                .end((err2, res2) => {
-                  should.not.exist(err2);
-                  res2.should.have.status(200);
-                  res2.text.should.equal('clear: all patches deleted');
-                  done();
-                });
-            });
+          done();
         });
-
-      // chai.request(server)
-      //   .put('/patchs/clear?test=true')
-      //   .end((err, res) => {
-      //     should.not.exist(err);
-      //     res.should.have.status(200);
-      //     res.text.should.equal('clear: all patches deleted');
-      //     done();
-      //   });
     }).timeout(3000);
+    it('undoing it', (done) => {
+      chai.request(server)
+        .put('/patch/undo')
+        .end((err1, res1) => {
+          should.not.exist(err1);
+          res1.should.have.status(200);
+          res1.text.should.equal('undo: patch 2 canceled');
+          done();
+        });
+    });
+  });
+
+  describe('PUT /patchs/clear', () => {
+    it("should return a warning (code 401): 'unauthorized'", (done) => {
+      chai.request(server)
+        .put('/patchs/clear')
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(401);
+          res.text.should.equal('unauthorized');
+          done();
+        });
+    });
+    it("should return 'clear: all patches deleted'", (done) => {
+      chai.request(server)
+        .put('/patchs/clear?test=true')
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(200);
+          res.text.should.equal('clear: all patches deleted');
+          done();
+        });
+    });
     it("should return a warning (code 201): 'nothing to clear'", (done) => {
       chai.request(server)
         .put('/patchs/clear?test=true')

--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -22,6 +22,7 @@ conn_string = "PG:host="\
     + " user=" + user + " password=" + password
 
 NB_BANDS = 3
+cpu_dispo = multiprocessing.cpu_count()
 
 
 def read_args(update):
@@ -176,10 +177,14 @@ def generate(update):
 
     print(" Découpage")
 
-    cpu_dispo = multiprocessing.cpu_count()
+    # cpu_dispo = multiprocessing.cpu_count()
+    if (cpu_dispo > len(list_filename)):
+        nb_thread = len(list_filename)
+    else:
+        nb_thread = cpu_dispo - 1
 
-    if (cpu_dispo > 2):
-        pool = multiprocessing.Pool(cpu_dispo - 1)
+    if (nb_thread > 1):
+        pool = multiprocessing.Pool(nb_thread)
         pool.map(cache.cut_image_1arg, args_cut_image)
 
         pool.close()

--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -208,7 +208,6 @@ def cut_image_1arg(arg):
     overviews = arg['overviews']
     tilebox = arg['tileBox']
 
-    opi_reech = gdal.Open(arg['opi']['path'])
     opi_gdal = gdal.Open(arg['opi']['path'])
 
     for level in range(overviews['dataSet']['level']['max'],
@@ -221,31 +220,30 @@ def cut_image_1arg(arg):
 
         resolution = overviews['resolution'] * 2 ** (overviews['level']['max'] - level)
 
-        if not level == overviews['level']['max']:
-            # RE-echantilonage de l'image
-            nb_col = tilebox[str(level)]['MaxTileCol'] - tilebox[str(level)]['MinTileCol'] + 1
-            nb_row = tilebox[str(level)]['MaxTileRow'] - tilebox[str(level)]['MinTileRow'] + 1
-            xmin = overviews['crs']['boundingBox']['xmin']\
-                + tilebox[str(level)]['MinTileCol'] * resolution * overviews['tileSize']['width']
-            ymax = overviews['crs']['boundingBox']['ymax']\
-                - tilebox[str(level)]['MinTileRow'] * resolution * overviews['tileSize']['height']
+        # RE-echantilonage de l'image
+        nb_col = tilebox[str(level)]['MaxTileCol'] - tilebox[str(level)]['MinTileCol'] + 1
+        nb_row = tilebox[str(level)]['MaxTileRow'] - tilebox[str(level)]['MinTileRow'] + 1
+        xmin = overviews['crs']['boundingBox']['xmin']\
+            + tilebox[str(level)]['MinTileCol'] * resolution * overviews['tileSize']['width']
+        ymax = overviews['crs']['boundingBox']['ymax']\
+            - tilebox[str(level)]['MinTileRow'] * resolution * overviews['tileSize']['height']
 
-            opi_reech = gdal.GetDriverByName('MEM').Create('',
-                                                           nb_col * overviews['tileSize']['width'],
-                                                           nb_row * overviews['tileSize']['height'],
-                                                           arg['gdalOption']['nbBands'],
-                                                           gdal.GDT_Byte)
-            opi_reech.SetGeoTransform((xmin,
-                                       resolution,
-                                       0,
-                                       ymax,
-                                       0,
-                                       -resolution))
-            opi_reech.SetProjection(arg['gdalOption']['spatialRef'])
-            opi_reech.FlushCache()
+        opi_reech = gdal.GetDriverByName('MEM').Create('',
+                                                       nb_col * overviews['tileSize']['width'],
+                                                       nb_row * overviews['tileSize']['height'],
+                                                       arg['gdalOption']['nbBands'],
+                                                       gdal.GDT_Byte)
+        opi_reech.SetGeoTransform((xmin,
+                                   resolution,
+                                   0,
+                                   ymax,
+                                   0,
+                                   -resolution))
+        opi_reech.SetProjection(arg['gdalOption']['spatialRef'])
+        opi_reech.FlushCache()
 
-            gdal.Warp(opi_reech, opi_gdal, resampleAlg=gdal.GRA_Average)
-            opi_gdal = opi_reech
+        gdal.Warp(opi_reech, opi_gdal, resampleAlg=gdal.GRA_Average)
+        opi_gdal = opi_reech
 
         for tile_x in range(tilebox[str(level)]['MinTileCol'],
                             tilebox[str(level)]['MaxTileCol'] + 1):

--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -243,8 +243,9 @@ def cut_image_1arg(arg):
         opi_reech.SetProjection(arg['gdalOption']['spatialRef'])
         opi_reech.FlushCache()
 
-        gdal.Warp(opi_reech, opi_gdal, resampleAlg=gdal.GRA_Average)
-        opi_gdal = opi_reech
+        # gdal.Warp(opi_reech, opi_gdal, resampleAlg=gdal.GRA_Average)
+        # opi_gdal = opi_reech
+        gdal.Warp(opi_reech, opi_gdal)
 
         for tile_x in range(tilebox[str(level)]['MinTileCol'],
                             tilebox[str(level)]['MaxTileCol'] + 1):

--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -214,7 +214,8 @@ def cut_image_1arg(arg):
                        overviews['dataSet']['level']['min'] - 1,
                        -1):
 
-        tps1 = time.process_time()
+        tps1_actif = time.process_time()
+        tps1 = time.perf_counter()
         if arg['verbose'] == 0:
             print('  (', arg['opi']['name'], ') level : ', level, sep="")
 
@@ -281,9 +282,11 @@ def cut_image_1arg(arg):
                 #               tile_param,
                 #               arg['gdalOption'])
 
-        tps2 = time.process_time()
+        tps2_actif = time.process_time()
+        tps2 = time.perf_counter()
         if arg['verbose'] > 0:
-            print('  (', arg['opi']['name'], ') level : ', level, ' in ', tps2 - tps1, sep="")
+            print('  (', arg['opi']['name'], ') level : ', level, ' in ', tps2 - tps1,
+                  ' (', tps2_actif - tps1_actif, ')', sep="")
 
 
 def progress_bar(nb_steps, nb_tiles, args_create_ortho_and_graph):


### PR DESCRIPTION
Objectif:
- Améliorer le temps de traitement du calcul du cache

**Cette PR est la version finale de différents test effectué sur le remplacement d'un gdal.Warp (par niveau) par un gdal.Warp (par OPI) suivi de gdalTranslate (par niveau) , qui bien que ne fait pas gagner de temps, devrait limiter l'usage mémoire lors du traitement**

Tests effectués :
- branche master
- partir du niveau le plus fin et faire une fois par niveau un ssech de l'OPI que l'on reutilise pour le niveau suivant
 - en sauvegardant sur le disque les ssech intermediare
 - en utilisant vsimem pour les ssech intermediare
 - en travaillant sur les ssech gardée en memoire

Rmq : en faisant des ssech a partir des ssech precedent on fais apparaitre des artefact du au fait que la methode par defaut est plusproche voisin:
j'ai donc aussi fait un test en changeant la methode de ssech : moyenne

**Cette PR est la version finale, qui ne fait pas gagner de temps mais devrait limiter l'usage memoire lors du traitement**
