### PR TITLE
[itowns] Patch : Sauvegarde et Visualisation {rebased}

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -42,7 +42,7 @@ paths:
       responses:
         '200':
           description: OK
-  '/patchs/clear':
+  '/patches/clear':
     put:
       tags:
         - patch
@@ -85,7 +85,7 @@ paths:
       responses:
         '200':
           description: OK
-  '/patchs':
+  '/patches':
     get:
       tags:
         - patch
@@ -259,7 +259,7 @@ paths:
             type: string
             enum:
               - overviews
-              - activePatchs
+              - activePatches
 
       responses:
         '200':

--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -259,6 +259,7 @@ paths:
             type: string
             enum:
               - overviews
+              - activePatchs
 
       responses:
         '200':

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -380,7 +380,7 @@ class Saisie {
 
   clear() {
     if (this.currentStatus === status.WAITING) return;
-    const ok = window.confirm('Voulez-vous effacer toutes les modifications?');
+    const ok = window.confirm('Voulez-vous effacer toutes les modifications ?');
     if (!ok) return;
     console.log('clear');
     this.currentStatus = status.WAITING;
@@ -388,6 +388,29 @@ class Saisie {
     this.message = 'calcul en cours';
 
     fetch(`${this.apiUrl}/patchs/clear?`,
+      {
+        method: 'PUT',
+      }).then((res) => {
+      this.cancelcurrentPolygon();
+      if (res.status === 200) {
+        this.refreshView(['ortho', 'graph']);
+      }
+      res.text().then((msg) => {
+        this.message = msg;
+      });
+    });
+  }
+
+  save() {
+    if (this.currentStatus === status.WAITING) return;
+    const ok = window.confirm('Voulez-vous sauvegarder toutes les modifications ?');
+    if (!ok) return;
+    console.log('save');
+    this.currentStatus = status.WAITING;
+    document.getElementById('viewerDiv').style.cursor = 'wait';
+    this.message = 'calcul en cours';
+
+    fetch(`${this.apiUrl}/patchs/save?`,
       {
         method: 'PUT',
       }).then((res) => {

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -50,7 +50,7 @@ class Saisie {
     if (redrawPatches) {
       this.layer.patches.config.opacity = this.layer.patches.colorLayer.opacity;
 
-      const json = await itowns.Fetcher.json(`${this.apiUrl}/json/activePatchs`);
+      const json = await itowns.Fetcher.json(`${this.apiUrl}/json/activePatches`);
       const features = await itowns.GeoJsonParser.parse(JSON.stringify(json),
         this.layer.patches.optionsGeoJsonParser);
       this.layer.patches.config.source = new itowns.FileSource({ features });
@@ -413,7 +413,7 @@ class Saisie {
     this.view.controls.setCursor('default', 'wait');
     this.message = 'calcul en cours';
 
-    fetch(`${this.apiUrl}/patchs/clear?`,
+    fetch(`${this.apiUrl}/patches/clear?`,
       {
         method: 'PUT',
       }).then((res) => {
@@ -436,7 +436,7 @@ class Saisie {
     document.getElementById('viewerDiv').style.cursor = 'wait';
     this.message = 'calcul en cours';
 
-    fetch(`${this.apiUrl}/patchs/save?`,
+    fetch(`${this.apiUrl}/patches/save?`,
       {
         method: 'PUT',
       }).then((res) => {

--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -25,17 +25,43 @@ class Saisie {
     this.mousePosition = null;
   }
 
-  refreshView(layers) {
+  async refreshView(layers) {
     // Pour le moment on force le rechargement complet des couches
+
+    let redrawPatches = false;
+
     layers.forEach((id) => {
       this.view.removeLayer(this.layer[id].colorLayer.id);
-      this.layer[id].config.opacity = this.layer[id].colorLayer.opacity;
-      this.layer[id].colorLayer = new itowns.ColorLayer(this.layer[id].name, this.layer[id].config);
-      this.view.addLayer(this.layer[id].colorLayer);
+      if (id !== 'patches') {
+        this.layer[id].config.opacity = this.layer[id].colorLayer.opacity;
+        this.layer[id].colorLayer = new itowns.ColorLayer(
+          this.layer[id].name,
+          this.layer[id].config,
+        );
+        this.view.addLayer(this.layer[id].colorLayer);
+      } else {
+        redrawPatches = true;
+      }
     });
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Ortho', 0);
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Opi', 1);
     itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Graph', 2);
+
+    if (redrawPatches) {
+      this.layer.patches.config.opacity = this.layer.patches.colorLayer.opacity;
+
+      const json = await itowns.Fetcher.json(`${this.apiUrl}/json/activePatchs`);
+      const features = await itowns.GeoJsonParser.parse(JSON.stringify(json),
+        this.layer.patches.optionsGeoJsonParser);
+      this.layer.patches.config.source = new itowns.FileSource({ features });
+      this.layer.patches.colorLayer = new itowns.ColorLayer(
+        this.layer.patches.name,
+        this.layer.patches.config,
+      );
+      this.view.addLayer(this.layer.patches.colorLayer);
+      itowns.ColorLayersOrdering.moveLayerToIndex(this.view, 'Patches', 3);
+    }
+
     this.view.notifyChange();
   }
 
@@ -118,7 +144,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       } else {
         this.message = "polygon: out of OPI's bounds";
       }
@@ -348,7 +374,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -370,7 +396,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -393,7 +419,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;
@@ -416,7 +442,7 @@ class Saisie {
       }).then((res) => {
       this.cancelcurrentPolygon();
       if (res.status === 200) {
-        this.refreshView(['ortho', 'graph']);
+        this.refreshView(['ortho', 'graph', 'patches']);
       }
       res.text().then((msg) => {
         this.message = msg;

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -15,280 +15,323 @@ console.log('serverAPI:', serverAPI, 'portAPI:', portAPI);
 
 const apiUrl = `http://${serverAPI}:${portAPI}`;
 
-itowns.Fetcher.json(`${apiUrl}/version`).then((obj) => {
-  document.getElementById('spAPIVersion_val').innerText = obj.version_git;
-})
+itowns.Fetcher.json(`${apiUrl}/version`)
+  .then((obj) => {
+    document.getElementById('spAPIVersion_val').innerText = obj.version_git;
+  })
   .catch(() => {
     document.getElementById('spAPIVersion_val').innerText = 'unknown';
   });
 
-// `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
-const viewerDiv = document.getElementById('viewerDiv');
+// check if string is in "x,y" format with x and y positive floats
+// return "null" if incorrect string format, otherwise [x, y] array
+function checkCoordString(coordStr) {
+  const rgxFloat = '\\s*([0-9]+[.]?[0-9]*)\\s*';
+  const rgxCoord = new RegExp(`^${rgxFloat},${rgxFloat}$`);
+  const rgxCatch = rgxCoord.exec(coordStr);
+  if (rgxCatch) {
+    return [parseFloat(rgxCatch[1]), parseFloat(rgxCatch[2])];
+  }
+  return null;
+}
+
+// fonction permettant d'afficher la valeur de l'echelle et du niveau de dezoom
+function updateScaleWidget(view, resolution) {
+  let distance = view.getPixelsToMeters(200);
+  let unit = 'm';
+  const dezoom = Math.fround(distance / (200 * resolution));
+  if (distance >= 1000) {
+    distance /= 1000;
+    unit = 'km';
+  }
+  if (distance <= 1) {
+    distance *= 100;
+    unit = 'cm';
+  }
+  document.getElementById('spanZoomWidget').innerHTML = dezoom <= 1 ? `zoom: ${1 / dezoom}` : `zoom: 1/${dezoom}`;
+  document.getElementById('spanScaleWidget').innerHTML = `${distance.toFixed(2)} ${unit}`;
+}
 
 async function main() {
   try {
     const overviews = await itowns.Fetcher.json(`${apiUrl}/json/overviews`);
 
-  // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
-  const crs = `${overviews.crs.type}:${overviews.crs.code}`;
-  if (crs !== 'EPSG:4326' && overviews.crs.proj4Definition) {
-    itowns.CRS.defs(crs, overviews.crs.proj4Definition);
-  } else {
-    throw new Error('EPSG proj4.defs not defined in overviews.json');
-  }
+    // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+    const crs = `${overviews.crs.type}:${overviews.crs.code}`;
+    if (crs !== 'EPSG:4326' && overviews.crs.proj4Definition) {
+      itowns.CRS.defs(crs, overviews.crs.proj4Definition);
+    } else {
+      throw new Error('EPSG proj4.defs not defined in overviews.json');
+    }
 
-  // limite du crs
-  const xOrigin = overviews.crs.boundingBox.xmin;
-  const yOrigin = overviews.crs.boundingBox.ymax;
+    // limite du crs
+    const xOrigin = overviews.crs.boundingBox.xmin;
+    const yOrigin = overviews.crs.boundingBox.ymax;
 
-  // limite du dataSet
-  const xmin = overviews.dataSet.boundingBox.LowerCorner[0];
-  const xmax = overviews.dataSet.boundingBox.UpperCorner[0];
-  const ymin = overviews.dataSet.boundingBox.LowerCorner[1];
-  const ymax = overviews.dataSet.boundingBox.UpperCorner[1];
+    // limite du dataSet
+    const xmin = overviews.dataSet.boundingBox.LowerCorner[0];
+    const xmax = overviews.dataSet.boundingBox.UpperCorner[0];
+    const ymin = overviews.dataSet.boundingBox.LowerCorner[1];
+    const ymax = overviews.dataSet.boundingBox.UpperCorner[1];
 
-  // Define geographic extent of level 0 : CRS, min/max X, min/max Y
-  const { resolution } = overviews;
-  const resolutionLv0 = resolution * 2 ** overviews.level.max;
-  const extent = new itowns.Extent(
-    crs,
-    xOrigin, xOrigin + (overviews.tileSize.width * resolutionLv0),
-    yOrigin - (overviews.tileSize.height * resolutionLv0), yOrigin,
-  );
+    // Define geographic extent of level 0 : CRS, min/max X, min/max Y
+    const { resolution } = overviews;
+    const resolutionLv0 = resolution * 2 ** overviews.level.max;
+    const extent = new itowns.Extent(
+      crs,
+      xOrigin, xOrigin + (overviews.tileSize.width * resolutionLv0),
+      yOrigin - (overviews.tileSize.height * resolutionLv0), yOrigin,
+    );
 
-  const dezoomInitial = 4;// to define
-  const resolInit = resolution * 2 ** dezoomInitial;
-  const xcenter = (xmin + xmax) * 0.5;
-  const ycenter = (ymin + ymax) * 0.5;
+    const dezoomInitial = 4;// to define
+    const resolInit = resolution * 2 ** dezoomInitial;
+    const xcenter = (xmin + xmax) * 0.5;
+    const ycenter = (ymin + ymax) * 0.5;
 
-  viewerDiv.height = viewerDiv.clientHeight;
-  viewerDiv.width = viewerDiv.clientWidth;
-  const placement = new itowns.Extent(
-    crs,
-    xcenter - viewerDiv.width * resolInit * 0.5, xcenter + viewerDiv.width * resolInit * 0.5,
-    ycenter - viewerDiv.height * resolInit * 0.5, ycenter + viewerDiv.height * resolInit * 0.5,
-  );
+    // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+    const viewerDiv = document.getElementById('viewerDiv');
+    viewerDiv.height = viewerDiv.clientHeight;
+    viewerDiv.width = viewerDiv.clientWidth;
 
-  const resolLvMax = resolution * 2 ** (overviews.level.max - overviews.dataSet.level.max);
-  const resolLvMin = resolution * 2 ** (overviews.level.max - overviews.dataSet.level.min);
+    const placement = new itowns.Extent(
+      crs,
+      xcenter - viewerDiv.width * resolInit * 0.5, xcenter + viewerDiv.width * resolInit * 0.5,
+      ycenter - viewerDiv.height * resolInit * 0.5, ycenter + viewerDiv.height * resolInit * 0.5,
+    );
 
-  // Instanciate PlanarView*
-  const zoomFactor = 2;// customizable
-  const view = new itowns.PlanarView(viewerDiv, extent, {
-    camera: {
-      type: itowns.CAMERA_TYPE.ORTHOGRAPHIC,
-    },
-    placement,
-    maxSubdivisionLevel: 30,
-    disableSkirt: true,
-    controls: {
-      enableSmartTravel: false,
-      zoomFactor,
-      maxResolution: resolLvMax * zoomFactor ** -1,
-      minResolution: resolLvMin * zoomFactor,
-    },
-  });
+    const resolLvMax = resolution * 2 ** (overviews.level.max - overviews.dataSet.level.max);
+    const resolLvMin = resolution * 2 ** (overviews.level.max - overviews.dataSet.level.min);
 
-  setupLoadingScreen(viewerDiv, view);
+    // Instanciate PlanarView*
+    const zoomFactor = 2;// customizable
+    const view = new itowns.PlanarView(viewerDiv, extent, {
+      camera: {
+        type: itowns.CAMERA_TYPE.ORTHOGRAPHIC,
+      },
+      placement,
+      maxSubdivisionLevel: 30,
+      disableSkirt: true,
+      controls: {
+        enableSmartTravel: false,
+        zoomFactor,
+        maxResolution: resolLvMax * zoomFactor ** -1,
+        minResolution: resolLvMin * zoomFactor,
+      },
+    });
 
-  view.isDebugMode = true;
-  const menuGlobe = new GuiTools('menuDiv', view);
-  menuGlobe.gui.width = 300;
+    setupLoadingScreen(viewerDiv, view);
 
-  const opacity = {
-    ortho: 1,
-    graph: 0.2,
-    opi: 0.5,
-  };
+    view.isDebugMode = true;
+    const menuGlobe = new GuiTools('menuDiv', view);
+    menuGlobe.gui.width = 300;
 
-  const layer = {};
-  ['ortho', 'graph', 'opi'].forEach((id) => {
-    layer[id] = {
-      name: id.charAt(0).toUpperCase() + id.slice(1),
-      config: {
-        source: {
-          url: `${apiUrl}/wmts`,
-          crs,
-          format: 'image/png',
-          name: id,
-          tileMatrixSet: overviews.identifier,
-          tileMatrixSetLimits: overviews.dataSet.limits,
+    const opacity = {
+      ortho: 1,
+      graph: 0.2,
+      opi: 0.5,
+      patches: 0.75,
+    };
+
+    const layer = {};
+    ['ortho', 'graph', 'opi'].forEach((id) => {
+      layer[id] = {
+        name: id.charAt(0).toUpperCase() + id.slice(1),
+        config: {
+          source: {
+            url: `${apiUrl}/wmts`,
+            crs,
+            format: 'image/png',
+            name: id,
+            tileMatrixSet: overviews.identifier,
+            tileMatrixSetLimits: overviews.dataSet.limits,
+          },
+          opacity: opacity[id],
         },
-        opacity: opacity[id],
+      };
+      layer[id].config.source = new itowns.WMTSSource(layer[id].config.source);
+      layer[id].config.source.extentInsideLimit = function extentInsideLimit() {
+        return true;
+      };
+
+      layer[id].colorLayer = new itowns.ColorLayer(layer[id].name, layer[id].config);
+      if (id === 'opi') layer[id].colorLayer.visible = false;
+      view.addLayer(layer[id].colorLayer);// .then(menuGlobe.addLayerGUI.bind(menuGlobe));
+    });
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Opi', 1);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Graph', 2);
+    // Et ouvrir l'onglet "Color Layers" par defaut ?
+
+    // Couche Patches
+    layer.patches = {
+      name: 'Patches',
+      config: {
+        transparent: true,
+        opacity: opacity.patches,
+      },
+      optionsGeoJsonParser: {
+        in: {
+          crs: 'EPSG:2154',
+        },
+        out: {
+          crs: view.tileLayer.extent.crs,
+          buildExtent: true,
+          mergeFeatures: true,
+          withNormal: false,
+          withAltitude: false,
+        },
       },
     };
-    layer[id].config.source = new itowns.WMTSSource(layer[id].config.source);
-    layer[id].config.source.extentInsideLimit = function extentInsideLimit() {
-      return true;
-    };
 
-    layer[id].colorLayer = new itowns.ColorLayer(layer[id].name, layer[id].config);
-    if (id === 'opi') layer[id].colorLayer.visible = false;
-    view.addLayer(layer[id].colorLayer);// .then(menuGlobe.addLayerGUI.bind(menuGlobe));
-  });
-  itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
-  itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Opi', 1);
-  itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Graph', 2);
-  // Et ouvrir l'onglet "Color Layers" par defaut ?
+    const json = await itowns.Fetcher.json(`${apiUrl}/json/activePatchs`);
+    const features = await itowns.GeoJsonParser.parse(
+      JSON.stringify(json),
+      layer.patches.optionsGeoJsonParser,
+    );
 
-  // Request redraw
-  view.notifyChange();
+    layer.patches.config.source = new itowns.FileSource({ features });
+    layer.patches.config.style = new itowns.Style({
+      stroke: {
+        color: 'Red',
+        width: 2,
+      },
+    });
 
-  const saisie = new Saisie(view, layer, apiUrl);
-  saisie.cliche = 'unknown';
-  saisie.message = '';
-  saisie.coord = `${xcenter.toFixed(2)},${ycenter.toFixed(2)}`;
-  saisie.color = [0, 0, 0];
-  saisie.controllers = {};
-  saisie.controllers.select = menuGlobe.gui.add(saisie, 'select');
-  saisie.controllers.cliche = menuGlobe.gui.add(saisie, 'cliche');
-  saisie.controllers.cliche.listen().domElement.parentElement.style.pointerEvents = 'none';
-  saisie.controllers.coord = menuGlobe.gui.add(saisie, 'coord');
-  saisie.controllers.coord.listen();// .domElement.parentElement.style.pointerEvents = 'none';
-  saisie.controllers.polygon = menuGlobe.gui.add(saisie, 'polygon');
-  saisie.controllers.undo = menuGlobe.gui.add(saisie, 'undo');
-  saisie.controllers.redo = menuGlobe.gui.add(saisie, 'redo');
-  if (process.env.NODE_ENV === 'development') saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
-  if (process.env.NODE_ENV === 'development') saisie.controllers.save = menuGlobe.gui.add(saisie, 'save');
-  saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
-  saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
+    layer.patches.colorLayer = new itowns.ColorLayer(
+      layer.patches.name,
+      layer.patches.config,
+    );
+    view.addLayer(layer.patches.colorLayer);
+    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Patches', 3);
 
-  viewerDiv.focus();
+    // Request redraw
+    view.notifyChange();
 
-  // fonction permettant d'afficher la valeur de l'echelle et du niveau de dezoom
-  function updateScaleWidget() {
-    let distance = view.getPixelsToMeters(200);
-    let unit = 'm';
-    const dezoom = Math.fround(distance / (200 * overviews.resolution));
-    if (distance >= 1000) {
-      distance /= 1000;
-      unit = 'km';
-    }
-    if (distance <= 1) {
-      distance *= 100;
-      unit = 'cm';
-    }
-    document.getElementById('spanZoomWidget').innerHTML = dezoom <= 1 ? `zoom: ${1 / dezoom}` : `zoom: 1/${dezoom}`;
-    document.getElementById('spanScaleWidget').innerHTML = `${distance.toFixed(2)} ${unit}`;
-  }
+    const saisie = new Saisie(view, layer, apiUrl);
+    saisie.cliche = 'unknown';
+    saisie.message = '';
+    saisie.coord = `${xcenter.toFixed(2)},${ycenter.toFixed(2)}`;
+    saisie.color = [0, 0, 0];
+    saisie.controllers = {};
+    saisie.controllers.select = menuGlobe.gui.add(saisie, 'select');
+    saisie.controllers.cliche = menuGlobe.gui.add(saisie, 'cliche');
+    saisie.controllers.cliche.listen().domElement.parentElement.style.pointerEvents = 'none';
+    saisie.controllers.coord = menuGlobe.gui.add(saisie, 'coord');
+    saisie.controllers.coord.listen();// .domElement.parentElement.style.pointerEvents = 'none';
+    saisie.controllers.polygon = menuGlobe.gui.add(saisie, 'polygon');
+    saisie.controllers.undo = menuGlobe.gui.add(saisie, 'undo');
+    saisie.controllers.redo = menuGlobe.gui.add(saisie, 'redo');
+    if (process.env.NODE_ENV === 'development') saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
+    if (process.env.NODE_ENV === 'development') saisie.controllers.save = menuGlobe.gui.add(saisie, 'save');
+    saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
+    saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
 
-  // check if string is in "x,y" format with x and y positive floats
-  // return "null" if incorrect string format, otherwise [x, y] array
-  function checkCoordString(coordStr) {
-    const rgxFloat = '\\s*([0-9]+[.]?[0-9]*)\\s*';
-    const rgxCoord = new RegExp(`^${rgxFloat},${rgxFloat}$`);
-    const rgxCatch = rgxCoord.exec(coordStr);
-    if (rgxCatch) {
-      return [parseFloat(rgxCatch[1]), parseFloat(rgxCatch[2])];
-    }
-    return null;
-  }
+    viewerDiv.focus();
 
-  view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
-    // eslint-disable-next-line no-console
-    console.info('View initialized');
-    updateScaleWidget();
-  });
-  view.addEventListener(itowns.PLANAR_CONTROL_EVENT.MOVED, () => {
-    // eslint-disable-next-line no-console
-    console.info('View moved');
-    if (view.controls.state === -1) {
-      updateScaleWidget();
-    }
-  });
+    view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
+      // eslint-disable-next-line no-console
+      console.info('View initialized');
+      updateScaleWidget(view, resolution);
+    });
+    view.addEventListener(itowns.PLANAR_CONTROL_EVENT.MOVED, () => {
+      // eslint-disable-next-line no-console
+      console.info('View moved');
+      if (view.controls.state === -1) {
+        updateScaleWidget(view, resolution);
+      }
+    });
 
-  viewerDiv.addEventListener('mousemove', (ev) => {
-    ev.preventDefault();
-    saisie.mousemove(ev);
-    return false;
-  }, false);
-  viewerDiv.addEventListener('click', (ev) => {
-    ev.preventDefault();
-    saisie.click(ev);
-    return false;
-  }, false);
-  viewerDiv.addEventListener('mousedown', (ev) => {
-    if (ev.button === 1) {
-      console.log('middle button clicked');
-      view.controls.initiateDrag();
-      view.controls.updateMouseCursorType();
-    }
-  });
+    viewerDiv.addEventListener('mousemove', (ev) => {
+      ev.preventDefault();
+      saisie.mousemove(ev);
+      return false;
+    }, false);
+    viewerDiv.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      saisie.click(ev);
+      return false;
+    }, false);
+    viewerDiv.addEventListener('mousedown', (ev) => {
+      if (ev.button === 1) {
+        console.log('middle button clicked');
+        view.controls.initiateDrag();
+        view.controls.updateMouseCursorType();
+      }
+    });
 
-  saisie.controllers.coord.onChange(() => {
-    if (!checkCoordString(saisie.coord)) {
-      saisie.message = 'Coordonnees non valides';
-    } else {
+    saisie.controllers.coord.onChange(() => {
+      if (!checkCoordString(saisie.coord)) {
+        saisie.message = 'Coordonnees non valides';
+      } else {
+        saisie.message = '';
+      }
+      return false;
+    });
+
+    saisie.controllers.coord.onFinishChange(() => {
+      const coords = checkCoordString(saisie.coord);
+      if (coords) {
+        itowns.CameraUtils.transformCameraToLookAtTarget(
+          view,
+          view.camera.camera3D,
+          {
+            coord: new itowns.Coordinates(crs, coords[0], coords[1]),
+            heading: 0,
+          },
+        );
+      }
       saisie.message = '';
-    }
-    return false;
-  });
+      return false;
+    });
 
-  saisie.controllers.coord.onFinishChange(() => {
-    const coords = checkCoordString(saisie.coord);
-    if (coords) {
+    window.addEventListener('keydown', (ev) => {
+      saisie.keydown(ev);
+      return false;
+    });
+    window.addEventListener('keyup', (ev) => {
+      saisie.keyup(ev);
+      return false;
+    });
+
+    document.getElementById('recenterBtn').addEventListener('click', () => {
+      // itowns.CameraUtils.animateCameraToLookAtTarget( ... ) <= bug itowns
       itowns.CameraUtils.transformCameraToLookAtTarget(
         view,
         view.camera.camera3D,
         {
-          coord: new itowns.Coordinates(crs, coords[0], coords[1]),
+          coord: new itowns.Coordinates(crs, xcenter, ycenter),
           heading: 0,
         },
       );
-    }
-    saisie.message = '';
-    return false;
-  });
+      return false;
+    }, false);
+    document.getElementById('zoomInBtn').addEventListener('click', () => {
+      console.log('Zoom-In');
+      if (view.getPixelsToMeters() > resolLvMax) {
+        view.camera.camera3D.zoom *= 2;
+        view.camera.camera3D.updateProjectionMatrix();
+        view.notifyChange(view.camera.camera3D);
+        updateScaleWidget(view, resolution);
+      }
+      return false;
+    });
+    document.getElementById('zoomOutBtn').addEventListener('click', () => {
+      console.log('Zoom-Out');
+      if (view.getPixelsToMeters() < resolLvMin) {
+        view.camera.camera3D.zoom *= 0.5;
+        view.camera.camera3D.updateProjectionMatrix();
+        view.notifyChange(view.camera.camera3D);
+        updateScaleWidget(view, resolution);
+      }
+      return false;
+    });
 
-  window.addEventListener('keydown', (ev) => {
-    saisie.keydown(ev);
-    return false;
-  });
-  window.addEventListener('keyup', (ev) => {
-    saisie.keyup(ev);
-    return false;
-  });
-
-  document.getElementById('recenterBtn').addEventListener('click', () => {
-    // bug itowns...
-    // itowns.CameraUtils.animateCameraToLookAtTarget( ... )
-    itowns.CameraUtils.transformCameraToLookAtTarget(
-      view,
-      view.camera.camera3D,
-      {
-        coord: new itowns.Coordinates(crs, xcenter, ycenter),
-        heading: 0,
-      },
-    );
-    return false;
-  }, false);
-  document.getElementById('zoomInBtn').addEventListener('click', () => {
-    console.log('Zoom-In');
-    if (view.getPixelsToMeters() > resolLvMax) {
-      view.camera.camera3D.zoom *= 2;
-      view.camera.camera3D.updateProjectionMatrix();
-      view.notifyChange(view.camera.camera3D);
-      updateScaleWidget();
-    }
-    return false;
-  });
-  document.getElementById('zoomOutBtn').addEventListener('click', () => {
-    console.log('Zoom-Out');
-    if (view.getPixelsToMeters() < resolLvMin) {
-      view.camera.camera3D.zoom *= 0.5;
-      view.camera.camera3D.updateProjectionMatrix();
-      view.notifyChange(view.camera.camera3D);
-      updateScaleWidget();
-    }
-    return false;
-  });
-
-  const helpContent = document.getElementById('help-content');
-  helpContent.style.visibility = 'hidden';
-  document.getElementById('help').addEventListener('click', () => {
-    helpContent.style.visibility = (helpContent.style.visibility === 'hidden') ? 'visible' : 'hidden';
-  });
-} catch (err) {
+    const helpContent = document.getElementById('help-content');
+    helpContent.style.visibility = 'hidden';
+    document.getElementById('help').addEventListener('click', () => {
+      helpContent.style.visibility = (helpContent.style.visibility === 'hidden') ? 'visible' : 'hidden';
+    });
+  } catch (err) {
     console.log(`${err.name}: ${err.message}`);
     if (`${err.name}: ${err.message}` === 'TypeError: Failed to fetch') {
       const newApiUrl = window.prompt(`API non accessible à l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl);

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -148,6 +148,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   saisie.controllers.undo = menuGlobe.gui.add(saisie, 'undo');
   saisie.controllers.redo = menuGlobe.gui.add(saisie, 'redo');
   if (process.env.NODE_ENV === 'development') saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
+  if (process.env.NODE_ENV === 'development') saisie.controllers.save = menuGlobe.gui.add(saisie, 'save');
   saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
   saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
 

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -177,8 +177,7 @@ async function main() {
           crs: view.tileLayer.extent.crs,
           buildExtent: true,
           mergeFeatures: true,
-          withNormal: false,
-          withAltitude: false,
+          structure: '2d',
         },
       },
     };

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -182,7 +182,7 @@ async function main() {
       },
     };
 
-    const json = await itowns.Fetcher.json(`${apiUrl}/json/activePatchs`);
+    const json = await itowns.Fetcher.json(`${apiUrl}/json/activePatches`);
     const features = await itowns.GeoJsonParser.parse(
       JSON.stringify(json),
       layer.patches.optionsGeoJsonParser,

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -25,8 +25,9 @@ itowns.Fetcher.json(`${apiUrl}/version`).then((obj) => {
 // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
 const viewerDiv = document.getElementById('viewerDiv');
 
-itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
-  const overviews = json;
+async function main() {
+  try {
+    const overviews = await itowns.Fetcher.json(`${apiUrl}/json/overviews`);
 
   // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
   const crs = `${overviews.crs.type}:${overviews.crs.code}`;
@@ -287,8 +288,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   document.getElementById('help').addEventListener('click', () => {
     helpContent.style.visibility = (helpContent.style.visibility === 'hidden') ? 'visible' : 'hidden';
   });
-})
-  .catch((err) => {
+} catch (err) {
     console.log(`${err.name}: ${err.message}`);
     if (`${err.name}: ${err.message}` === 'TypeError: Failed to fetch') {
       const newApiUrl = window.prompt(`API non accessible à l'adresse renseignée (${apiUrl}). Veuillez entrer une adresse valide :`, apiUrl);
@@ -297,4 +297,6 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
     } else {
       window.alert(err);
     }
-  });
+  }
+}
+main();

--- a/regress/patch.js
+++ b/regress/patch.js
@@ -71,10 +71,10 @@ describe('Patch', () => {
     });
   });
 
-  describe('GET /patchs', () => {
+  describe('GET /patches', () => {
     it('should return an valid geoJson', (done) => {
       chai.request(server)
-        .get('/patchs')
+        .get('/patches')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(200);
@@ -131,10 +131,10 @@ describe('Patch', () => {
     });
   });
 
-  describe('PUT /patchs/clear', () => {
+  describe('PUT /patches/clear', () => {
     it("should return a warning (code 401): 'unauthorized'", (done) => {
       chai.request(server)
-        .put('/patchs/clear')
+        .put('/patches/clear')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(401);
@@ -172,7 +172,7 @@ describe('Patch', () => {
 
               // Pour faire le clear
               chai.request(server)
-                .put('/patchs/clear?test=true')
+                .put('/patches/clear?test=true')
                 .end((err2, res2) => {
                   should.not.exist(err2);
                   res2.should.have.status(200);
@@ -193,7 +193,7 @@ describe('Patch', () => {
     }).timeout(3000);
     it("should return a warning (code 201): 'nothing to clear'", (done) => {
       chai.request(server)
-        .put('/patchs/clear?test=true')
+        .put('/patches/clear?test=true')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(201);
@@ -203,10 +203,10 @@ describe('Patch', () => {
     });
   });
 
-  describe('PUT /patchs/save', () => {
+  describe('PUT /patches/save', () => {
     it("should return a warning (code 401): 'unauthorized'", (done) => {
       chai.request(server)
-        .put('/patchs/save')
+        .put('/patches/save')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(401);
@@ -263,7 +263,7 @@ describe('Patch', () => {
 
                   // then save
                   chai.request(server)
-                    .put('/patchs/save?test=true')
+                    .put('/patches/save?test=true')
                     .end((err3, res3) => {
                       should.not.exist(err3);
                       res3.should.have.status(200);
@@ -276,7 +276,7 @@ describe('Patch', () => {
     }).timeout(3000);
     it("should return a warning (code 201): 'nothing to save'", (done) => {
       chai.request(server)
-        .put('/patchs/save?test=true')
+        .put('/patches/save?test=true')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(201);

--- a/regress/patch.js
+++ b/regress/patch.js
@@ -130,6 +130,7 @@ describe('Patch', () => {
         });
     });
   });
+
   describe('PUT /patchs/clear', () => {
     it("should return a warning (code 401): 'unauthorized'", (done) => {
       chai.request(server)
@@ -197,6 +198,89 @@ describe('Patch', () => {
           should.not.exist(err);
           res.should.have.status(201);
           res.text.should.equal('nothing to clear');
+          done();
+        });
+    });
+  });
+
+  describe('PUT /patchs/save', () => {
+    it("should return a warning (code 401): 'unauthorized'", (done) => {
+      chai.request(server)
+        .put('/patchs/save')
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(401);
+          res.text.should.equal('unauthorized');
+          done();
+        });
+    });
+    it("should return 'save: all active patches saved'", (done) => {
+      // first add a patch
+      chai.request(server)
+        .post('/patch')
+        .send({
+          type: 'FeatureCollection',
+          crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2154' } },
+          features: [
+            {
+              type: 'Feature',
+              properties: { color: [58, 149, 47], cliche: '19FD5606Ax00020_16371' },
+              geometry: { type: 'Polygon', coordinates: [[[230748, 6759646], [230752, 6759646], [230752, 6759644], [230748, 6759644], [230748, 6759646]]] },
+            }],
+        })
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(200);
+          const resJson = JSON.parse(res.text);
+          resJson.should.be.a('array');
+
+          // and a second patch
+          chai.request(server)
+            .post('/patch')
+            .send({
+              type: 'FeatureCollection',
+              crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2154' } },
+              features: [
+                {
+                  type: 'Feature',
+                  properties: { color: [58, 149, 47], cliche: '19FD5606Ax00020_16371' },
+                  geometry: { type: 'Polygon', coordinates: [[[230748, 6759646], [230752, 6759646], [230752, 6759644], [230748, 6759644], [230748, 6759646]]] },
+                }],
+            })
+            .end((err1, res1) => {
+              should.not.exist(err1);
+              res1.should.have.status(200);
+              const res1Json = JSON.parse(res1.text);
+              res1Json.should.be.a('array');
+
+              // then undo it
+              chai.request(server)
+                .put('/patch/undo')
+                .end((err2, res2) => {
+                  should.not.exist(err2);
+                  res2.should.have.status(200);
+                  res2.text.should.equal('undo: patch 2 canceled');
+
+                  // then save
+                  chai.request(server)
+                    .put('/patchs/save?test=true')
+                    .end((err3, res3) => {
+                      should.not.exist(err3);
+                      res3.should.have.status(200);
+                      res3.text.should.equal('save: all active patches saved');
+                      done();
+                    });
+                });
+            });
+        });
+    }).timeout(3000);
+    it("should return a warning (code 201): 'nothing to save'", (done) => {
+      chai.request(server)
+        .put('/patchs/save?test=true')
+        .end((err, res) => {
+          should.not.exist(err);
+          res.should.have.status(201);
+          res.text.should.equal('nothing to save');
           done();
         });
     });

--- a/routes/file.js
+++ b/routes/file.js
@@ -13,7 +13,7 @@ const parentDir = `${global.dir_cache}`;
 router.get('/json/:typefile', [
   param('typefile')
     .exists().withMessage(createErrMsg.missingParameter('typefile'))
-    .isIn(['overviews', 'test'])
+    .isIn(['overviews', 'activePatchs', 'test'])
     .withMessage(createErrMsg.invalidParameter('typefile')),
 ], validateParams,
 (req, res) => {

--- a/routes/file.js
+++ b/routes/file.js
@@ -7,22 +7,21 @@ const fs = require('fs');
 const validateParams = require('../paramValidation/validateParams');
 const createErrMsg = require('../paramValidation/createErrMsg');
 
-// Dossier contenant les differents fichiers
-const parentDir = `${global.dir_cache}`;
-
 router.get('/json/:typefile', [
   param('typefile')
     .exists().withMessage(createErrMsg.missingParameter('typefile'))
-    .isIn(['overviews', 'activePatchs', 'test'])
+    .isIn(['overviews', 'activePatches', 'test'])
     .withMessage(createErrMsg.invalidParameter('typefile')),
 ], validateParams,
 (req, res) => {
   debug('~~~getJson~~~');
   const params = matchedData(req);
   const { typefile } = params;
-
-  const filePath = path.join(parentDir, `${typefile}.json`);
-
+  const parentDir = {
+    overviews: global.dir_cache,
+    activePatches: path.join(global.dir_cache, 'patch'),
+  };
+  const filePath = path.join(`${parentDir[typefile]}`, `${typefile}.json`);
   try {
     if (!fs.existsSync(filePath)) {
       const err = new Error();

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -539,7 +539,10 @@ router.put('/patches/save', [], (req, res) => {
     });
   });
   const date = new Date(Date.now()).toISOString().replace(/-|T|:/g, '').substr(0, 14);
-  fs.writeFileSync(path.join(global.dir_cache, `save_${date}Z.json`), JSON.stringify(req.app.activePatches, null, 4));
+  req.app.savedPatches.nbSave += 1;
+  req.app.savedPatches.save.push({ name: `${date}Z.json` });
+  fs.writeFileSync(path.join(global.dir_cache, 'patch', 'save', `${date}Z.json`), JSON.stringify(req.app.activePatches, null, 4));
+  fs.writeFileSync(path.join(global.dir_cache, 'patch', 'savedPatches.json'), JSON.stringify(req.app.savedPatches, null, 4));
   req.app.activePatches.features = [];
   req.app.unactivePatches.features = [];
   fs.writeFileSync(path.join(global.dir_cache, 'patch', 'activePatches.json'), JSON.stringify(req.app.activePatches, null, 4));

--- a/serveur.js
+++ b/serveur.js
@@ -54,27 +54,17 @@ try {
   app.cache_mtd = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'cache_mtd.json')));
   app.overviews = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'overviews.json')));
 
-  try {
-    app.activePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'activePatchs.json')));
-  } catch (err) {
-    app.activePatchs = {
-      type: 'FeatureCollection',
-      name: 'annotation',
-      crs: {
-        type: 'name',
-        properties: {
-          name: 'urn:ogc:def:crs:EPSG::2154',
-        },
-      },
-      features: [],
-    };
-    fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(app.activePatchs, null, 4));
+  // gestion des patchs
+
+  const dirPatch = path.join(global.dir_cache, 'patch');
+  if (!fs.existsSync(dirPatch)) {
+    fs.mkdirSync(dirPatch);
   }
 
   try {
-    app.unactivePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'unactivePatchs.json')));
+    app.activePatches = JSON.parse(fs.readFileSync(path.join(dirPatch, 'activePatches.json')));
   } catch (err) {
-    app.unactivePatchs = {
+    app.activePatches = {
       type: 'FeatureCollection',
       name: 'annotation',
       crs: {
@@ -85,7 +75,35 @@ try {
       },
       features: [],
     };
-    fs.writeFileSync(path.join(global.dir_cache, 'unactivePatchs.json'), JSON.stringify(app.unactivePatchs, null, 4));
+    fs.writeFileSync(path.join(dirPatch, 'activePatches.json'), JSON.stringify(app.activePatches, null, 4));
+  }
+
+  try {
+    app.unactivePatches = JSON.parse(fs.readFileSync(path.join(dirPatch, 'unactivePatches.json')));
+  } catch (err) {
+    app.unactivePatches = {
+      type: 'FeatureCollection',
+      name: 'annotation',
+      crs: {
+        type: 'name',
+        properties: {
+          name: 'urn:ogc:def:crs:EPSG::2154',
+        },
+      },
+      features: [],
+    };
+    fs.writeFileSync(path.join(dirPatch, 'unactivePatches.json'), JSON.stringify(app.unactivePatches, null, 4));
+  }
+
+  try {
+    app.savedPatches = JSON.parse(fs.readFileSync(path.join(dirPatch, 'savedPatches.json')));
+  } catch (err) {
+    app.savedPatches = {
+      nbSave: 0,
+      save: [],
+    };
+    fs.writeFileSync(path.join(dirPatch, 'savedPatches.json'), JSON.stringify(app.savedPatches, null, 4));
+    fs.mkdirSync(path.join(dirPatch, 'save'));
   }
 
   app.use(cors());


### PR DESCRIPTION
PR #117 rebasée.

[rebasée sur PR #152  update itowns 2.33 ]

Cette PR ajoute deux fonctionnalités :
- l'ajout d'une couche vectorielle 'retouches' permettant la visualisation de l'ensemble des patchs actifs (à tout instants)
- un bouton 'save' permettant la sauvegarde (et la pérennisation) de tous les patchs actifs, un fichier save_'date'.json est crée contenant les polygones de retouches sauvegardés.

Modifications:
- utilisation de async/await (pour remplacer itowns.fetcher())
