### PR TITLE
Gestion des branches de cache basé sur les caches en COG

### DIFF
--- a/cog_path.js
+++ b/cog_path.js
@@ -39,6 +39,7 @@ function getTilePath(X, Y, Z, overviews) {
   // on a donc nbTiles (qui est une puissance de 2)
   // correspond au facteur max
   if (factor > nbTiles) {
+    debug('Niveau de zoom non dispo');
     const error = new Error();
     error.msg = {
       status: 'zoom non dispo',

--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -6,6 +6,8 @@ servers:
   - url: "http://localhost:8081"
     description: "Serveur de dev"
 tags:
+  - name: branch
+    description: Gestion des branches
   - name: wmts
     description: Requête sur les tuiles
   - name: graph
@@ -24,39 +26,92 @@ paths:
       responses:
         '200':
           description: OK
-  '/patch/undo':
+  '/branches':
+    get:
+      tags:
+        - branch
+      summary: "Récupération de la liste des branches"
+      description: ""
+      responses:
+        '200':
+          description: OK
+  '/branch':
+    post:
+      tags:
+        - branch
+      summary: "Création d'une branche"
+      description: ""
+      parameters:
+        - in: query
+          name: name
+          required: true
+          schema:
+            type: string
+          example: "maBranche"
+      responses:
+        '200':
+          description: OK
+  '/{branchId}/patch/undo':
     put:
       tags:
         - patch
       summary: "Annulation de la dernière modification"
       description: ""
+      parameters:
+        - in: path
+          name: branchId
+          description: l'identifiant de la branche
+          required: true
+          schema:
+            type: integer
       responses:
         '200':
           description: OK
-  '/patch/redo':
+  '/{branchId}/patch/redo':
     put:
       tags:
         - patch
       summary: "Reprise en compte de la dernière modification annulée"
       description: ""
+      parameters:
+        - in: path
+          name: branchId
+          description: l'identifiant de la branche
+          required: true
+          schema:
+            type: integer
       responses:
         '200':
           description: OK
-  '/patchs/clear':
+  '/{branchId}/patches/clear':
     put:
       tags:
         - patch
       summary: "Annulation de toutes les modifications"
       description: ""
+      parameters:
+        - in: path
+          name: branchId
+          description: l'identifiant de la branche
+          required: true
+          schema:
+            type: integer
       responses:
         '200':
           description: OK
-  '/patch':
+  '/{branchId}/patch':
     post:
       tags:
         - patch
       summary: "Application d'un patch de correction"
       description: "Mise a jour du graph de mosaiquage a partir d'un geoJSON"
+      parameters:
+        - in: path
+          name: branchId
+          description: l'identifiant de la branche
+          required: true
+          schema:
+            type: integer
       requestBody:
         description: polygone à patcher (geoJson)
         required: true
@@ -85,22 +140,35 @@ paths:
       responses:
         '200':
           description: OK
-  '/patchs':
+  '/{branchId}/patches':
     get:
       tags:
         - patch
       summary: "Récupération de tous les patchs de correction"
       description: ""
+      parameters:
+        - in: path
+          name: branchId
+          description: l'identifiant de la branche
+          required: true
+          schema:
+            type: integer
       responses:
         '200':
           description: OK
-  '/graph':
+  '/{branchId}/graph':
     get:
       tags:
         - graph
       summary: "Récupération de l'identifiant du cliche"
       description: ""
       parameters:
+        - in: path
+          name: branchId
+          description: l'identifiant de la branche
+          required: true
+          schema:
+            type: integer
         - in: query
           name: x
           required: true
@@ -117,13 +185,19 @@ paths:
         '200':
           description: OK
 
-  '/wmts':
+  '/{branchId}/wmts':
     get:
       tags:
         - wmts
       summary: "service wmts pour ortho et graph"
       description: ""
       parameters:
+        - in: path
+          name: branchId
+          description: l'identifiant de la branche
+          required: true
+          schema:
+            type: integer
         - in: query
           name: SERVICE
           required: true

--- a/gdal_processing.js
+++ b/gdal_processing.js
@@ -124,10 +124,13 @@ function processPatchAsync(patch, blocSize) {
     // Modification du graph
     debug('ouverture de l image');
     debug(patch);
+    const urlGraph = patch.withOrig ? patch.urlGraphOrig : patch.urlGraph;
+    const urlOrtho = patch.withOrig ? patch.urlOrthoOrig : patch.urlOrtho;
+    const { urlOpi } = patch;
     Promise.all([
-      gdal.openAsync(patch.urlGraph),
-      gdal.openAsync(patch.urlOpi),
-      gdal.openAsync(patch.urlOrtho),
+      gdal.openAsync(urlGraph),
+      gdal.openAsync(urlOpi),
+      gdal.openAsync(urlOrtho),
     ]).then((dsArray) => {
       const dsGraph = dsArray[0];
       const dsOpi = dsArray[1];

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -25,8 +25,16 @@ itowns.Fetcher.json(`${apiUrl}/version`).then((obj) => {
 // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
 const viewerDiv = document.getElementById('viewerDiv');
 
-itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
-  const overviews = json;
+const getOverviews = itowns.Fetcher.json(`${apiUrl}/json/overviews`);
+const getBranches = itowns.Fetcher.json(`${apiUrl}/branches`);
+Promise.all([getOverviews, getBranches]).then((results) => {
+  const overviews = results[0];
+  const branches = results[1];
+  const currentBranch = branches[0];
+  const branchNames = [];
+  branches.forEach((element) => {
+    branchNames.push(element.name);
+  });
 
   // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
   const crs = `${overviews.crs.type}:${overviews.crs.code}`;
@@ -152,7 +160,7 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
       name: id.charAt(0).toUpperCase() + id.slice(1),
       config: {
         source: {
-          url: `${apiUrl}/wmts`,
+          url: `${apiUrl}/${currentBranch.id}/wmts`,
           crs,
           format: 'image/png',
           name: source[id],
@@ -186,9 +194,11 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   // Request redraw
   view.notifyChange();
 
-  const saisie = new Saisie(view, layer, apiUrl);
+  const saisie = new Saisie(view, layer, apiUrl, currentBranch.id);
   saisie.cliche = 'unknown';
   saisie.message = '';
+  saisie.branch = currentBranch.name;
+  saisie.idBranch = currentBranch.id;
   saisie.coord = `${xcenter.toFixed(2)},${ycenter.toFixed(2)}`;
   saisie.color = [0, 0, 0];
   saisie.controllers = {};
@@ -203,6 +213,18 @@ itowns.Fetcher.json(`${apiUrl}/json/overviews`).then((json) => {
   if (process.env.NODE_ENV === 'development') saisie.controllers.clear = menuGlobe.gui.add(saisie, 'clear');
   saisie.controllers.message = menuGlobe.gui.add(saisie, 'message');
   saisie.controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
+  saisie.controllers.branch = menuGlobe.gui.add(saisie, 'branch', branchNames);
+  saisie.controllers.branch.onChange((value) => {
+    console.log('new active branch : ', value);
+    branches.forEach((branch) => {
+      if (branch.name === value) {
+        saisie.branch = value;
+        saisie.idBranch = branch.id;
+        saisie.changeBranchId(saisie.idBranch);
+      }
+    });
+  });
+  saisie.controllers.createBranch = menuGlobe.gui.add(saisie, 'createBranch');
 
   viewerDiv.focus();
 

--- a/middlewares/branch.js
+++ b/middlewares/branch.js
@@ -1,0 +1,18 @@
+const { matchedData } = require('express-validator');
+
+function validBranch(req, res, next) {
+  const params = matchedData(req);
+  const { idBranch } = params;
+  const selectedBranches = req.app.branches.filter((item) => item.id === Number(idBranch));
+  if (selectedBranches.length === 0) {
+    return res.status(400).json({
+      errors: 'branch does not exist',
+    });
+  }
+  [req.selectedBranch] = selectedBranches;
+  return next();
+}
+
+module.exports = {
+  validBranch,
+};

--- a/regress/branch.js
+++ b/regress/branch.js
@@ -1,0 +1,54 @@
+const chai = require('chai');
+chai.use(require('chai-http'));
+chai.use(require('chai-json-schema'));
+
+const should = chai.should();
+const server = require('..');
+
+describe('Branch', () => {
+  after((done) => {
+    server.close();
+    done();
+  });
+
+  describe('GET /branches', () => {
+    describe('query all branches ', () => {
+      it('should return a list of branches', (done) => {
+        chai.request(server)
+          .get('/branches')
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(200);
+            done();
+          });
+      });
+    });
+    describe('add a valid branch', () => {
+      it('should return a branchId', (done) => {
+        chai.request(server)
+          .post('/branch')
+          .query({ name: 'test' })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(200);
+            const resJson = JSON.parse(res.text);
+            resJson.should.have.property('id').equal(1);
+            resJson.should.have.property('name').equal('test');
+            done();
+          });
+      });
+    });
+    describe('add a non valid branch', () => {
+      it('should return a error', (done) => {
+        chai.request(server)
+          .post('/branch')
+          .query({ name: 'test' })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(406);
+            done();
+          });
+      });
+    });
+  });
+});

--- a/regress/graph.js
+++ b/regress/graph.js
@@ -30,11 +30,11 @@ describe('Graph', () => {
     done();
   });
 
-  describe('GET /graph', () => {
+  describe('GET /0/graph', () => {
     describe('query: x=0 & y=0', () => {
       it("should return a 'out of bounds'", (done) => {
         chai.request(server)
-          .get('/graph')
+          .get('/0/graph')
           .query({ x: 0, y: 0 })
           .end((err, res) => {
             should.not.exist(err);
@@ -52,7 +52,7 @@ describe('Graph', () => {
       // outside of graph but inside the image frame
       it("should return a 'out of graph'", (done) => {
         chai.request(server)
-          .get('/graph')
+          .get('/0/graph')
           .query({ x: 230757, y: 6759654 })
           .end((err, res) => {
             should.not.exist(err);
@@ -68,7 +68,7 @@ describe('Graph', () => {
     describe('query: x=230755 & y=6759650', () => {
       it('should return a Json { "color": Array(3), "cliche": 19FD5606Ax00020_16371 }', (done) => {
         chai.request(server)
-          .get('/graph')
+          .get('/0/graph')
           .query({ x: 230755, y: 6759650 })
           .end((err, res) => {
             should.not.exist(err);
@@ -84,7 +84,7 @@ describe('Graph', () => {
     describe('query: x=230749.8 & y=6759645.1', () => {
       it('should return a Json { "color": Array(3), "cliche": 19FD5606Ax00020_16372 }', (done) => {
         chai.request(server)
-          .get('/graph')
+          .get('/0/graph')
           .query({ x: 230749.8, y: 6759645.1 })
           .end((err, res) => {
             should.not.exist(err);
@@ -101,7 +101,7 @@ describe('Graph', () => {
       // image not yet in the cache
       it("should return a 'out of graph'", (done) => {
         chai.request(server)
-          .get('/graph')
+          .get('/0/graph')
           .query({ x: 230747, y: 6759643 })
           .end((err, res) => {
             should.not.exist(err);
@@ -112,6 +112,18 @@ describe('Graph', () => {
             resJson.should.have.property('cliche').equal('out of graph');
 
             done();
+          });
+      });
+    });
+    describe('query: x=230747 & y=6759643', () => {
+      // branch doesn't exist
+      it("should return a 'branch does not exist'", (done) => {
+        chai.request(server)
+          .get('/12/graph')
+          .query({ x: 230747, y: 6759643 })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(400); done();
           });
       });
     });

--- a/regress/patch.js
+++ b/regress/patch.js
@@ -12,11 +12,11 @@ describe('Patch', () => {
     done();
   });
 
-  describe('POST /patch', () => {
+  describe('POST /0/patch', () => {
     describe('body: {}', () => {
       it('should return an error', (done) => {
         chai.request(server)
-          .post('/patch')
+          .post('/0/patch')
           .end((err, res) => {
             should.not.exist(err);
             res.should.have.status(400);
@@ -27,7 +27,7 @@ describe('Patch', () => {
     describe('body: polygon geoJson', () => {
       it('should apply the patch and return the liste of tiles impacted', (done) => {
         chai.request(server)
-          .post('/patch')
+          .post('/0/patch')
           .send({
             type: 'FeatureCollection',
             crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2154' } },
@@ -50,7 +50,7 @@ describe('Patch', () => {
       // TODO gestion des polygones Out of bounds
       it("should get an error: 'File(s) missing", (done) => {
         chai.request(server)
-          .post('/patch')
+          .post('/0/patch')
           .send({
             type: 'FeatureCollection',
             crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2154' } },
@@ -70,10 +70,10 @@ describe('Patch', () => {
     });
   });
 
-  describe('GET /patchs', () => {
+  describe('GET /0/patches', () => {
     it('should return an valid geoJson', (done) => {
       chai.request(server)
-        .get('/patchs')
+        .get('/0/patches')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(200);
@@ -85,10 +85,10 @@ describe('Patch', () => {
     });
   });
 
-  describe('PUT /patch/undo', () => {
+  describe('PUT /0/patch/undo', () => {
     it("should return 'undo: patch 1 canceled'", (done) => {
       chai.request(server)
-        .put('/patch/undo')
+        .put('/0/patch/undo')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(200);
@@ -98,7 +98,7 @@ describe('Patch', () => {
     });
     it("should return a warning (code 201): 'nothing to undo'", (done) => {
       chai.request(server)
-        .put('/patch/undo')
+        .put('/0/patch/undo')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(201);
@@ -107,10 +107,10 @@ describe('Patch', () => {
         });
     });
   });
-  describe('PUT /patch/redo', () => {
+  describe('PUT /0/patch/redo', () => {
     it("should return 'redo: patch 1 reapplied'", (done) => {
       chai.request(server)
-        .put('/patch/redo')
+        .put('/0/patch/redo')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(200);
@@ -120,7 +120,7 @@ describe('Patch', () => {
     });
     it("should return a warning (code 201): 'nothing to redo'", (done) => {
       chai.request(server)
-        .put('/patch/redo')
+        .put('/0/patch/redo')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(201);
@@ -129,10 +129,10 @@ describe('Patch', () => {
         });
     });
   });
-  describe('PUT /patchs/clear', () => {
+  describe('PUT /0/patches/clear', () => {
     it("should return a warning (code 401): 'unauthorized'", (done) => {
       chai.request(server)
-        .put('/patchs/clear')
+        .put('/0/patches/clear')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(401);
@@ -143,7 +143,7 @@ describe('Patch', () => {
     it("should return 'clear: all patches deleted'", (done) => {
       // Ajout d'un nouveau patch
       chai.request(server)
-        .post('/patch')
+        .post('/0/patch')
         .send({
           type: 'FeatureCollection',
           crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2154' } },
@@ -162,7 +162,7 @@ describe('Patch', () => {
 
           // Avant de l'annuler
           chai.request(server)
-            .put('/patch/undo')
+            .put('/0/patch/undo')
             .end((err1, res1) => {
               should.not.exist(err1);
               res1.should.have.status(200);
@@ -170,7 +170,7 @@ describe('Patch', () => {
 
               // Pour faire le clear
               chai.request(server)
-                .put('/patchs/clear?test=true')
+                .put('/0/patches/clear?test=true')
                 .end((err2, res2) => {
                   should.not.exist(err2);
                   res2.should.have.status(200);
@@ -181,7 +181,7 @@ describe('Patch', () => {
         });
 
       // chai.request(server)
-      //   .put('/patchs/clear?test=true')
+      //   .put('/0/patches/clear?test=true')
       //   .end((err, res) => {
       //     should.not.exist(err);
       //     res.should.have.status(200);
@@ -191,7 +191,7 @@ describe('Patch', () => {
     }).timeout(9000);
     it("should return a warning (code 201): 'nothing to clear'", (done) => {
       chai.request(server)
-        .put('/patchs/clear?test=true')
+        .put('/0/patches/clear?test=true')
         .end((err, res) => {
           should.not.exist(err);
           res.should.have.status(201);

--- a/regress/wmts.js
+++ b/regress/wmts.js
@@ -11,10 +11,10 @@ describe('Wmts', () => {
     done();
   });
 
-  describe('GET /wmts?SERVICE=OTHER&REQUEST=GetCapabilities', () => {
+  describe('GET /0/wmts?SERVICE=OTHER&REQUEST=GetCapabilities', () => {
     it('should return an error', (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({ REQUEST: 'GetCapabilities', SERVICE: 'OTHER', VERSION: '1.0.0' })
         .end((err, res) => {
           should.not.exist(err);
@@ -26,10 +26,10 @@ describe('Wmts', () => {
     });
   });
 
-  describe('GET /wmts?SERVICE=WMTS&REQUEST=Other', () => {
+  describe('GET /0/wmts?SERVICE=WMTS&REQUEST=Other', () => {
     it('should return an error', (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({ REQUEST: 'Other', SERVICE: 'WMTS', VERSION: '1.0.0' })
         .end((err, res) => {
           should.not.exist(err);
@@ -45,7 +45,7 @@ describe('Wmts', () => {
   describe('GetCapabilities', () => {
     it('should return the Capabilities.xml', (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({ REQUEST: 'GetCapabilities', SERVICE: 'WMTS', VERSION: '1.0.0' })
         .end((err, res) => {
           should.not.exist(err);
@@ -61,7 +61,7 @@ describe('Wmts', () => {
   describe('GetTile', () => {
     it('should return an error', (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({
           REQUEST: 'GetTile', SERVICE: 'WMTS', VERSION: '1.0.0', TILEMATRIXSET: 'LAMB93_5cm', TILEMATRIX: 12, TILEROW: 0, TILECOL: 0, FORMAT: 'image/autre', LAYER: 'ortho', STYLE: 'normal',
         })
@@ -76,7 +76,7 @@ describe('Wmts', () => {
 
     it('should return a png image', (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({
           REQUEST: 'GetTile', SERVICE: 'WMTS', VERSION: '1.0.0', TILEMATRIXSET: 'LAMB93_5cm', TILEMATRIX: 12, TILEROW: 0, TILECOL: 0, FORMAT: 'image/png', LAYER: 'ortho', STYLE: 'normal',
         })
@@ -90,7 +90,7 @@ describe('Wmts', () => {
     });
     it('should return a jpeg image', (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({
           REQUEST: 'GetTile', SERVICE: 'WMTS', VERSION: '1.0.0', TILEMATRIXSET: 'LAMB93_5cm', TILEMATRIX: 12, TILEROW: 0, TILECOL: 0, FORMAT: 'image/jpeg', LAYER: 'ortho', STYLE: 'normal',
         })
@@ -105,7 +105,7 @@ describe('Wmts', () => {
 
     it("should return the OPI '19FD5606Ax00020_16371' as png", (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({
           REQUEST: 'GetTile', SERVICE: 'WMTS', VERSION: '1.0.0', TILEMATRIXSET: 'LAMB93_5cm', TILEMATRIX: 12, TILEROW: 0, TILECOL: 0, FORMAT: 'image/png', LAYER: 'opi', Name: '19FD5606Ax00020_16371', STYLE: 'normal',
         })
@@ -124,7 +124,7 @@ describe('Wmts', () => {
     describe('query: LAYER=other', () => {
       it('should return an error', (done) => {
         chai.request(server)
-          .get('/wmts')
+          .get('/0/wmts')
           .query({
             SERVICE: 'WMTS',
             REQUEST: 'GetFeatureInfo',
@@ -151,7 +151,7 @@ describe('Wmts', () => {
     describe('query: STYLE=other', () => {
       it('should return an error', (done) => {
         chai.request(server)
-          .get('/wmts')
+          .get('/0/wmts')
           .query({
             SERVICE: 'WMTS',
             REQUEST: 'GetFeatureInfo',
@@ -178,7 +178,7 @@ describe('Wmts', () => {
     describe('query: TILEMATRIXSET=OTHER', () => {
       it('should return an error', (done) => {
         chai.request(server)
-          .get('/wmts')
+          .get('/0/wmts')
           .query({
             SERVICE: 'WMTS',
             REQUEST: 'GetFeatureInfo',
@@ -204,7 +204,7 @@ describe('Wmts', () => {
     });
     it('should return an xml', (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({
           SERVICE: 'WMTS',
           REQUEST: 'GetFeatureInfo',
@@ -229,7 +229,7 @@ describe('Wmts', () => {
     });
     it("should return a warning: 'missing'", (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({
           SERVICE: 'WMTS',
           REQUEST: 'GetFeatureInfo',
@@ -253,7 +253,7 @@ describe('Wmts', () => {
     });
     it("should return an error: 'out of bounds'", (done) => {
       chai.request(server)
-        .get('/wmts')
+        .get('/0/wmts')
         .query({
           SERVICE: 'WMTS',
           REQUEST: 'GetFeatureInfo',

--- a/routes/branch.js
+++ b/routes/branch.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const debug = require('debug')('branch');
+const router = require('express').Router();
+const { matchedData, query } = require('express-validator');
+
+const validateParams = require('../paramValidation/validateParams');
+const createErrMsg = require('../paramValidation/createErrMsg');
+
+router.get('/branches', (req, res) => {
+  debug('~~~get branches~~~');
+  const branchWithoutPatches = [];
+  req.app.branches.forEach((branch) => {
+    branchWithoutPatches.push({ id: branch.id, name: branch.name });
+  });
+  res.status(200).send(JSON.stringify(branchWithoutPatches));
+});
+
+router.post('/branch', [
+  query('name')
+    .exists().withMessage(createErrMsg.missingParameter('name')),
+], validateParams, (req, res) => {
+  const params = matchedData(req);
+  const { name } = params;
+  debug('~~~post branch~~~');
+  // on vérifie si le nom est deja pris
+  let largestId = 0;
+  let ok = true;
+  req.app.branches.forEach((branch) => {
+    largestId = Math.max(largestId, branch.id);
+    if (branch.name === name) {
+      ok = false;
+    }
+  });
+  if (!ok) {
+    res.status(406).send('A branch with this name already exists');
+    return;
+  }
+  // on crée la nouvelle branche
+  req.app.branches.push({
+    id: largestId + 1,
+    name,
+    activePatches: {
+      type: 'FeatureCollection',
+      name: 'annotation',
+      crs: {
+        type: 'name',
+        properties: {
+          name: 'urn:ogc:def:crs:EPSG::2154',
+        },
+      },
+      features: [],
+    },
+    unactivePatches: {
+      type: 'FeatureCollection',
+      name: 'annotation',
+      crs: {
+        type: 'name',
+        properties: {
+          name: 'urn:ogc:def:crs:EPSG::2154',
+        },
+      },
+      features: [],
+    },
+  });
+  fs.writeFileSync(path.join(global.dir_cache, 'branches.json'), JSON.stringify(req.app.branches, null, 4));
+
+  res.status(200).send(JSON.stringify({ name, id: largestId + 1 }));
+});
+
+module.exports = router;

--- a/serveur.js
+++ b/serveur.js
@@ -39,6 +39,7 @@ const graph = require('./routes/graph.js');
 const file = require('./routes/file.js');
 const patch = require('./routes/patch.js');
 const { misc, gitVersion } = require('./routes/misc.js');
+const branch = require('./routes/branch.js');
 
 try {
   // desactive la mise en cache des images par le navigateur - OK Chrome/Chromium et Firefox
@@ -55,37 +56,37 @@ try {
   app.overviews = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'overviews.json')));
 
   try {
-    app.activePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'activePatchs.json')));
+    app.branches = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'branches.json')));
   } catch (err) {
-    app.activePatchs = {
-      type: 'FeatureCollection',
-      name: 'annotation',
-      crs: {
-        type: 'name',
-        properties: {
-          name: 'urn:ogc:def:crs:EPSG::2154',
+    app.branches = [
+      {
+        id: 0,
+        name: 'master',
+        activePatches: {
+          type: 'FeatureCollection',
+          name: 'annotation',
+          crs: {
+            type: 'name',
+            properties: {
+              name: 'urn:ogc:def:crs:EPSG::2154',
+            },
+          },
+          features: [],
+        },
+        unactivePatches: {
+          type: 'FeatureCollection',
+          name: 'annotation',
+          crs: {
+            type: 'name',
+            properties: {
+              name: 'urn:ogc:def:crs:EPSG::2154',
+            },
+          },
+          features: [],
         },
       },
-      features: [],
-    };
-    fs.writeFileSync(path.join(global.dir_cache, 'activePatchs.json'), JSON.stringify(app.activePatchs, null, 4));
-  }
-
-  try {
-    app.unactivePatchs = JSON.parse(fs.readFileSync(path.join(global.dir_cache, 'unactivePatchs.json')));
-  } catch (err) {
-    app.unactivePatchs = {
-      type: 'FeatureCollection',
-      name: 'annotation',
-      crs: {
-        type: 'name',
-        properties: {
-          name: 'urn:ogc:def:crs:EPSG::2154',
-        },
-      },
-      features: [],
-    };
-    fs.writeFileSync(path.join(global.dir_cache, 'unactivePatchs.json'), JSON.stringify(app.unactivePatchs, null, 4));
+    ];
+    fs.writeFileSync(path.join(global.dir_cache, 'branches.json'), JSON.stringify(app.branches, null, 4));
   }
 
   app.use(cors());
@@ -112,6 +113,7 @@ try {
   app.use('/', file);
   app.use('/', patch);
   app.use('/', misc);
+  app.use('/', branch);
 
   app.use('/itowns', express.static('itowns'));
 


### PR DESCRIPTION
# Motivation

Pouvoir avoir plusieurs versions des modifications du cache sous forme de branches. C'est la première étape pour la gestion du travail collaboratif sur PackO (c'est-à-dire à plusieurs sur un même cache). Pour éviter les conflits et les incohérences, chaque utilisateur devra travailler seul, sur sa branche. Il faudra ajouter des outils de fusion de branches ainsi que des vérifications permettant de s'assurer que deux personnes ne travaillent pas en même temps sur une branche.

Cela fera l'objet d'au moins 2 autres PR.

Cette première PR permet:

- [X] de créer des branches de cache via l'API depuis la vue iTowns
- [X] de choisir à tout moment le cache qui est utilisé dans l'interface iTowns 