### PR TITLE
Correction régression port API et refactorisation version

### DIFF
--- a/routes/misc.js
+++ b/routes/misc.js
@@ -1,18 +1,13 @@
 const debug = require('debug')('misc');
 const router = require('express').Router();
-const { gitDescribe } = require('git-describe');
+const { gitDescribeSync } = require('git-describe');
 
-gitDescribe(__dirname, (err, gitInfo) => {
-  if (err) {
-    debug(err);
-  }
-  debug(`Git version: ${gitInfo.raw}`);
-  global.swaggerDocument.info.version = gitInfo.raw;
-});
+const gitVersion = gitDescribeSync(__dirname).raw;
+debug(`Git version: ${gitVersion}`);
 
 router.get('/version', (req, res) => {
   debug('~~~getVersion~~~');
-  res.status(200).send({ version_git: global.swaggerDocument.info.version });
+  res.status(200).send({ version_git: gitVersion });
 });
 
-module.exports = router;
+module.exports = { misc: router, gitVersion };

--- a/serveur.js
+++ b/serveur.js
@@ -104,9 +104,9 @@ try {
 
   // swaggerDocument global var because needed in routes/misc.js
   global.swaggerDocument = YAML.load('./doc/swagger.yml');
-  app.use('/doc', swaggerUi.serve, swaggerUi.setup(global.swaggerDocument, options));
   global.swaggerDocument.info.version = '???';
   global.swaggerDocument.servers[0].url = app.urlApi;
+  app.use('/doc', swaggerUi.serve, swaggerUi.setup(global.swaggerDocument, options));
 
   app.use('/', wmts);
   app.use('/', graph);

--- a/serveur.js
+++ b/serveur.js
@@ -38,7 +38,7 @@ const wmts = require('./routes/wmts.js');
 const graph = require('./routes/graph.js');
 const file = require('./routes/file.js');
 const patch = require('./routes/patch.js');
-const misc = require('./routes/misc.js');
+const { misc, gitVersion } = require('./routes/misc.js');
 
 try {
   // desactive la mise en cache des images par le navigateur - OK Chrome/Chromium et Firefox
@@ -102,11 +102,10 @@ try {
     customCss: '.swagger-ui .topbar { display: none }',
   };
 
-  // swaggerDocument global var because needed in routes/misc.js
-  global.swaggerDocument = YAML.load('./doc/swagger.yml');
-  global.swaggerDocument.info.version = '???';
-  global.swaggerDocument.servers[0].url = app.urlApi;
-  app.use('/doc', swaggerUi.serve, swaggerUi.setup(global.swaggerDocument, options));
+  const swaggerDocument = YAML.load('./doc/swagger.yml');
+  swaggerDocument.servers[0].url = app.urlApi;
+  swaggerDocument.info.version = gitVersion;
+  app.use('/doc', swaggerUi.serve, swaggerUi.setup(swaggerDocument, options));
 
   app.use('/', wmts);
   app.use('/', graph);


### PR DESCRIPTION
## Motivation
Problème sur l'initialisation du port serveur - si on indique autre valeur que celle par défaut, les requêtes n'aboutissent pas la version de l'API n'est pas récupérée / affichée  

Cette PR propose donc : 
- une correction sur l'initialisation du port de l'API
- une refactorisation du code sur la récupération et affichage de la version de l'API