### PR TITLE
fix WMTS for gdal

### DIFF
--- a/routes/wmts.js
+++ b/routes/wmts.js
@@ -15,6 +15,17 @@ const gdalProcessing = require('../gdal_processing');
 const validateParams = require('../paramValidation/validateParams');
 const createErrMsg = require('../paramValidation/createErrMsg');
 
+// 06-121r3_OGC_Web_Services_Common_Specification_version_1.1.0_with_Corrigendum
+// section 11.5.2
+// The capitalization of parameter names when KVP encoded shall be case insensitive,
+// meaning that parameter names may have mixed case or not.
+router.use((req, _res, next) => {
+  Object.keys(req.query).forEach((key) => {
+    req.query[key.toUpperCase()] = req.query[key];
+  });
+  next();
+});
+
 router.get('/:idBranch/wmts', [
   param('idBranch')
     .exists().withMessage(createErrMsg.missingParameter('idBranch'))
@@ -264,7 +275,7 @@ router.get('/:idBranch/wmts', [
           'ows:HTTP': {
             'ows:Get': {
               $: {
-                'xlink:href': `${req.app.urlApi}/wmts`,
+                'xlink:href': `${req.app.urlApi}/${idBranch}/wmts`,
               },
               'ows:Constraint': {
                 $: {


### PR DESCRIPTION
En lien avec #181 
Deux corrections:

- on passe tous les noms de paramètres en lettres capitales sur les requêtes WMTS pour être insensible à la casse (conformément à la spec du protocole)
- on ajoute le numéro de la branche dans l'URL des services donnée par le GetCapabilities

La compatibilité a été vérifiée avec QGIS (qui utilise des noms de paramètre en capitale) et avec les commandes gdal (qui utilise du CamelCase). 
Exemple de commande gdal (à tester sur le cache_test):
```
gdalwarp "WMTS:http://localhost:8081/0/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities,layer=ortho" out-packo.tif -te 230600 6759400 230800 6759700 -tr 0.8 0.8
```