### PR TITLE
ajout d'une interface pour choisir l'épaisseur des contours

### DIFF
--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -45,6 +45,9 @@ class Saisie {
       this.view.removeLayer(this.layer[id].colorLayer.id);
       this.layer[id].config.opacity = this.layer[id].colorLayer.opacity;
       this.layer[id].config.visible = this.layer[id].colorLayer.visible;
+      if (this.layer[id].colorLayer.effect_parameter) {
+        this.layer[id].config.effect_parameter = this.layer[id].colorLayer.effect_parameter;
+      }
 
       // ColorLayer
       if (id !== 'patches') {
@@ -55,7 +58,7 @@ class Saisie {
         this.view.addLayer(this.layer[id].colorLayer);
         if (id === 'contour') {
           this.layer[id].colorLayer.effect_type = itowns.colorLayerEffects.customEffect;
-          this.layer[id].colorLayer.effect_parameter = 1.0;
+          this.layer[id].colorLayer.effect_parameter = this.layer[id].config.effect_parameter;
           this.layer[id].colorLayer.magFilter = 1003;// itowns.THREE.NearestFilter;
           this.layer[id].colorLayer.minFilter = 1003;// itowns.THREE.NearestFilter;
         }


### PR DESCRIPTION
# Motivation

Pouvoir choisir l'épaisseur des contours (demande de l'utilisateur final).

# Principe

Le shader en place permet déjà de modifier l'épaisseur avec le paramètre **effect_parameter** mais il n'y avait pas de moyen dans l'interface pour modifier ce paramètre. Dans cette PR, on modifie la fonction **addImageryLayerGUI** d'iTowns pour gérer cette option.
Le résultat: le paramètre est accessible pour la couche **Contour** avec un curseur sous le nom **thickness**.
Cette solution n'est pas totalement satisfaisante parce qu'il faudrait veiller à rester compatible avec les évolutions de la méthode **addImageryLayerGUI**: à discuter avec l'équipe du projet iTowns.