### PR TITLE
fix(monitor): set opi to visible after select

### DIFF
--- a/itowns/Saisie.js
+++ b/itowns/Saisie.js
@@ -286,6 +286,7 @@ class Saisie {
               this.controllers.cliche.__li.style.backgroundColor = `rgb(${this.color[0]},${this.color[1]},${this.color[2]})`;
               // On modifie la couche OPI
               this.layer.opi.config.source.url = this.layer.opi.config.source.url.replace(/LAYER=.*&FORMAT/, `LAYER=opi&Name=${json.cliche}&FORMAT`);
+              this.layer.opi.colorLayer.visible = true;
               this.refreshView(['opi']);
               this.validClicheSelected = true;
             }


### PR DESCRIPTION
La PR précédente, permettant la persistance de la propriété 'visible' d'une couche à entrainé une régression sur la sélection d'une nouvelle OPI restant a non visible.
Cette PR vise à corriger ce bug.