### PR TITLE
Suppression num patch dans l'API et Augmenter la couverture des test

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    # branches: [ master ]
 
 jobs:
   API:

--- a/db/db.js
+++ b/db/db.js
@@ -79,7 +79,7 @@ async function getCachePath(pgClient, idBranch) {
 }
 
 async function getBranches(pgClient, idCache) {
-  debug('~~getBranches');
+  debug(`~~getBranches (idCache: ${idCache})`);
   try {
     let results;
     if (idCache) {
@@ -176,7 +176,7 @@ async function getActivePatches(pgClient, idBranch) {
 
 async function getUnactivePatches(pgClient, idBranch) {
   try {
-    debug(`~~getActivePatches (idBranch: ${idBranch})`);
+    debug(`~~getUnactivePatches (idBranch: ${idBranch})`);
 
     const sql = "SELECT json_build_object('type', 'FeatureCollection', "
     + "'features', json_agg(ST_AsGeoJSON(t.*)::json)) FROM "
@@ -278,7 +278,7 @@ async function deactivatePatch(pgClient, idPatch) {
 
 async function reactivatePatch(pgClient, idPatch) {
   try {
-    debug(`~~deactivatePatch (idPatch: ${idPatch})`);
+    debug(`~~reactivatePatch (idPatch: ${idPatch})`);
 
     const sql = format('UPDATE patches SET active=True WHERE id=%s', idPatch);
 
@@ -297,7 +297,7 @@ async function reactivatePatch(pgClient, idPatch) {
 
 async function deletePatches(pgClient, idBranch) {
   try {
-    debug(`~~deactivatePatch (idBranch: ${idBranch})`);
+    debug(`~~deletePatches (idBranch: ${idBranch})`);
 
     const sql = format('DELETE FROM patches WHERE id_branch=%s', idBranch);
 

--- a/db/db.js
+++ b/db/db.js
@@ -238,23 +238,19 @@ async function getOpiId(pgClient, name) {
   }
 }
 
-async function insertPatch(pgClient, idBranch, patch, opiId) {
+async function insertPatch(pgClient, idBranch, geometry, opiId) {
   try {
     debug(`~~insertPatch (idBranch: ${idBranch})`);
 
-    const sql = format('INSERT INTO patches (num, geom, id_branch, id_opi) values (%s, ST_GeomFromGeoJSON(\'%s\'), %s, %s) RETURNING id as id_patch',
-      patch.properties.num,
-      JSON.stringify(patch.geometry),
+    const sql = format('INSERT INTO patches (geom, id_branch, id_opi) values (ST_GeomFromGeoJSON(%L), %s, %s) RETURNING id as id_patch, num',
+      JSON.stringify(geometry),
       idBranch,
       opiId);
-
     debug(sql);
 
-    const results = await pgClient.query(
-      sql,
-    );
+    const results = await pgClient.query(sql);
 
-    return results.rows[0].id_patch;
+    return results.rows[0];
   } catch (error) {
     debug('Error: ', error);
     throw error;

--- a/db/db.js
+++ b/db/db.js
@@ -5,7 +5,7 @@ async function getCaches(pgClient) {
   debug('~~getCaches');
   try {
     const results = await pgClient.query(
-      'SELECT id, name, path FROM caches',
+      'SELECT id, name, path FROM caches ORDER BY id ASC',
     );
     return results.rows;
   } catch (error) {
@@ -84,7 +84,7 @@ async function getBranches(pgClient, idCache) {
     let results;
     if (idCache) {
       results = await pgClient.query(
-        'SELECT name, id FROM branches WHERE id_cache=$1',
+        'SELECT name, id FROM branches WHERE id_cache=$1 ORDER BY id ASC',
         [idCache],
       );
     } else {

--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -71,11 +71,24 @@ paths:
                     example: "LAMB93_5cm"
                   crs:
                     type: object
-                    example:
-                      {
-                        "type":"name",
-                        "properties":{
-                          "name":"urn:ogc:def:crs:EPSG::2154"}}
+                    properties:
+                      type:
+                        type: string
+                        example: "EPSG"
+                      code:
+                        type: integer
+                        example: 2154
+                      boundingBox:
+                        type: object
+                        example:
+                          {
+                            "xmin": 0,
+                            "xmax": 1200000,
+                            "ymin": 6090000,
+                            "ymax": 7200000}
+                      proj4Definition:
+                        type: string
+                        example: "+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
                   resolution:
                     type: integer
                     example: 0.05
@@ -110,6 +123,19 @@ paths:
                               76]}
                   dataSet:
                     type: object
+                    properties:
+                      boundingBox:
+                        type: object
+                        example:
+                          {
+                            "LowerCorner": [
+                                230745.6,
+                                6759641.6],
+                            "UpperCorner": [
+                                230758.4,
+                                6759654.4]}
+                      limits:
+                        type: object
       responses:
         '200':
           description: OK

--- a/middlewares/branch.js
+++ b/middlewares/branch.js
@@ -1,52 +1,6 @@
 const debug = require('debug')('branch');
-const fs = require('fs');
-const path = require('path');
 const { matchedData } = require('express-validator');
 const db = require('../db/db');
-
-async function validBranch(req, _res, next) {
-  debug('~~~validBranch~~~');
-  if (req.error) {
-    next();
-    return;
-  }
-  const params = matchedData(req);
-  const { idBranch } = params;
-
-  try {
-    req.dir_cache = await db.getCachePath(req.client, idBranch);
-  } catch (error) {
-    debug(error);
-    req.error = {
-      msg: 'branch does not exist',
-      code: 400,
-      function: 'validBranch',
-    };
-    debug('ERROR', req.error);
-  }
-  next();
-}
-
-async function getOverviews(req, _res, next) {
-  if (req.error) {
-    next();
-    return;
-  }
-  const overviewsFileName = path.join(req.dir_cache, 'overviews.json');
-  fs.readFile(overviewsFileName, (error, data) => {
-    if (error) {
-      debug(error);
-      req.error = {
-        msg: 'overviews does not exist',
-        code: 400,
-        function: 'getOverviews',
-      };
-    } else {
-      req.overviews = JSON.parse(data);
-    }
-    next();
-  });
-}
 
 async function getBranches(req, _res, next) {
   debug('~~~get branches~~~');
@@ -59,13 +13,14 @@ async function getBranches(req, _res, next) {
   let branches;
   try {
     branches = await db.getBranches(req.client, idCache);
+    if (this.column) {
+      req.result = { json: branches.map((branch) => branch[this.column]), code: 200 };
+    } else {
+      req.result = { json: branches, code: 200 };
+    }
   } catch (error) {
     debug(error);
-  }
-  if (this.column) {
-    req.result = { json: branches.map((branch) => branch[this.column]), code: 200 };
-  } else {
-    req.result = { json: branches, code: 200 };
+    req.error = error;
   }
   next();
 }
@@ -85,11 +40,17 @@ async function insertBranch(req, _res, next) {
     req.result = { json: { name, id: idBranch }, code: 200 };
   } catch (error) {
     debug(error);
-    req.error = {
-      msg: 'A branch with this name already exists',
-      code: 406,
-      function: 'insertBranch',
-    };
+    if (error.constraint === 'branches_name_id_cache_key') {
+      req.error = {
+        json: {
+          msg: 'A branch with this name already exists.',
+          function: 'insertBranch',
+        },
+        code: 406,
+      };
+    } else {
+      req.error = error;
+    }
   }
   next();
 }
@@ -106,22 +67,26 @@ async function deleteBranch(req, _res, next) {
   try {
     const branchName = await db.deleteBranch(req.client, idBranch, global.id_cache);
     debug(branchName);
-    req.result = { json: `branche '${branchName}' détruite`, code: 200 };
+    if (branchName === null) {
+      req.error = {
+        json: {
+          msg: `Branch '${idBranch}' can't be deleted.`,
+          function: 'deleteBranch',
+        },
+        code: 406,
+      };
+    } else {
+      req.result = { json: `branche '${branchName}' détruite`, code: 200 };
+    }
   } catch (error) {
     debug(error);
-    req.error = {
-      msg: `Branch '${idBranch}' can't be deleted`,
-      code: 406,
-      function: 'deleteBranch',
-    };
+    req.error = error;
   }
   next();
 }
 
 module.exports = {
-  validBranch,
   getBranches,
   insertBranch,
   deleteBranch,
-  getOverviews,
 };

--- a/middlewares/patch.js
+++ b/middlewares/patch.js
@@ -187,21 +187,27 @@ async function postPatch(req, _res, next) {
   const { overviews } = req;
   const params = matchedData(req);
   const geoJson = params.geoJSON;
+  const { geometry } = geoJson.features[0];
   const { idBranch } = params;
 
-  const activePatches = await db.getActivePatches(req.client, idBranch);
+  // const activePatches = await db.getActivePatches(req.client, idBranch);
 
-  let newPatchNum = 0;
-  for (let i = 0; i < activePatches.features.length; i += 1) {
-    const id = activePatches.features[i].properties.num;
-    if (newPatchNum < id) newPatchNum = id;
-  }
+  // let newPatchNum = 0;
+  // for (let i = 0; i < activePatches.features.length; i += 1) {
+  //   const id = activePatches.features[i].properties.num;
+  //   if (newPatchNum < id) newPatchNum = id;
+  // }
 
-  newPatchNum += 1;
+  // newPatchNum += 1;
 
   // const newPatchNum = Math.max(
   //   ...activePatches.features.map((feature) => feature.properties.num),
   // ) + 1;
+
+  const opiId = await db.getOpiId(req.client, geoJson.features[0].properties.cliche);
+  const patchInserted = await db.insertPatch(req.client, idBranch, geometry, opiId);
+  const patchId = patchInserted.id_patch;
+  const newPatchNum = patchInserted.num;
 
   const cogs = getCOGs(geoJson.features, overviews);
   debug('cogs =', cogs);
@@ -292,9 +298,6 @@ async function postPatch(req, _res, next) {
         // activePatches.features = activePatches.features.concat(
         //  geoJson.features,
         // );
-
-        const opiId = await db.getOpiId(req.client, geoJson.features[0].properties.cliche);
-        const patchId = await db.insertPatch(req.client, idBranch, geoJson.features[0], opiId);
 
         // ajouter les slabs correspondant au patch dans la table correspondante
         const result = await db.insertSlabs(req.client, patchId, geoJson.features[0]);

--- a/middlewares/returnMsg.js
+++ b/middlewares/returnMsg.js
@@ -1,6 +1,7 @@
 module.exports = function returnMsg(req, res) {
   if (req.error) {
-    res.status(req.error.code).json(req.error);
+    res.status(req.error.code ? req.error.code : 500)
+      .json(req.error.json ? req.error.json : req.error);
   } else if (req.result.json) {
     res.status(req.result.code).json(req.result.json);
   } else if (req.result.xml) {

--- a/middlewares/wmts.js
+++ b/middlewares/wmts.js
@@ -284,9 +284,11 @@ function wmts(req, _res, next) {
 
       if (!fs.existsSync(url)) {
         req.error = {
-          msg: 'out of bounds',
+          json: {
+            status: 'out of bounds',
+            localisation: 'GetFeatureInfo',
+          },
           code: 400,
-          function: 'GetFeatureInfo',
         };
         next();
         return;
@@ -324,9 +326,11 @@ function wmts(req, _res, next) {
           next();
         }).catch(() => {
           req.error = {
-            msg: 'out of bounds',
+            json: {
+              status: 'out of bounds',
+              localisation: 'GetFeatureInfo',
+            },
             code: 400,
-            function: 'GetFeatureInfo',
           };
           next();
         });

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "serveur.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "c8 -r text mocha regress --cache cache_test",
-    "test-coveralls": "c8 -r lcov --report-dir=coverage mocha regress --cache cache_regress",
+    "test": "c8 -r text mocha regress",
+    "test-coveralls": "c8 -r lcov --report-dir=coverage mocha regress",
     "build-dev": "cd itowns && npm install && npm run build-dev",
     "start-dev": "cross-env NODE_ENV=development node serveur.js",
     "build": "cd itowns && npm install && npm run build",

--- a/paramValidation/validateParams.js
+++ b/paramValidation/validateParams.js
@@ -2,21 +2,21 @@ const debug = require('debug')('validateParams');
 const { validationResult } = require('express-validator');
 
 module.exports = function validateParams(req, res, next) {
+  if (req.error) {
+    next();
+    return;
+  }
   debug('~~~validateParams~~~');
-  const result = validationResult(req);
-
-  if (!result.isEmpty()) {
-    // return res.status(400).json({
-    //   status: result.array({ onlyFirstError: true })[0].msg,
-    //   errors: result.array({ onlyFirstError: true }),
-    // });
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
     req.error = {
-      status: result.array({ onlyFirstError: true })[0].msg,
-      errors: result.array({ onlyFirstError: true }),
+      json: errors.array().map((error) => ({
+        status: error.msg,
+        error,
+      })),
       code: 400,
-      function: 'insertCache',
     };
   }
   debug('~~~next~~~');
-  return next();
+  next();
 };

--- a/regress/1_file.js
+++ b/regress/1_file.js
@@ -14,7 +14,7 @@ describe('Files', () => {
   });
 
   describe('GET /files/{filetype}', () => {
-    describe('filetype = graph', () => {
+    describe('filetype = overviews', () => {
       it('should return a json file', (done) => {
         chai.request(app)
           .get('/json/overviews')
@@ -32,7 +32,7 @@ describe('Files', () => {
       });
     });
     describe('filetype = test (test.json is not a file)', () => {
-      it('should return an error', (done) => {
+      it('should return an error (Missing file)', (done) => {
         chai.request(app)
           .get('/json/test')
           .query({ cachePath })
@@ -48,7 +48,7 @@ describe('Files', () => {
       });
     });
     describe('filetype = overviews and cachePath = testPath (non valide)', () => {
-      it('should return an error', (done) => {
+      it('should return an error (Missing folder)', (done) => {
         chai.request(app)
           .get('/json/overviews')
           .query({ cachePath: 'testPath' })
@@ -59,6 +59,22 @@ describe('Files', () => {
             res.body.should.be.a('object');
             res.body.should.have.property('status').equal("Le dossier demandé (testPath) n'existe pas");
 
+            done();
+          });
+      });
+    });
+    describe('filetype = other and no cachePath', () => {
+      it('should return an error (Missing folder)', (done) => {
+        chai.request(app)
+          .get('/json/other')
+          .query({})
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(400);
+            const resJson = JSON.parse(res.text);
+            resJson.should.be.an('array').to.have.lengthOf(2);
+            resJson[0].should.have.property('status').equal("Le paramètre 'typefile' n'est pas valide.");
+            resJson[1].should.have.property('status').equal("Le paramètre 'cachePath' est requis.");
             done();
           });
       });

--- a/regress/2_cache.js
+++ b/regress/2_cache.js
@@ -30,6 +30,8 @@ describe('Cache', () => {
           .end((err, res) => {
             should.not.exist(err);
             res.should.have.status(200);
+            const resJson = JSON.parse(res.text);
+            resJson.should.be.an('array');
             done();
           });
       });
@@ -69,6 +71,29 @@ describe('Cache', () => {
           .end((err, res) => {
             should.not.exist(err);
             res.should.have.status(406);
+            const resJson = JSON.parse(res.text);
+            resJson.should.be.an('object');
+            resJson.should.have.property('msg').equal('A cache with this name already exists.');
+            done();
+          });
+      });
+    });
+    describe('insert an overviews.json', () => {
+      it(' list_OPI = [] => should return an error', (done) => {
+        delete overviews.list_OPI;
+        chai.request(app)
+          .post('/cache')
+          .query({
+            name: cacheName,
+            path: cachePath,
+          })
+          .send(overviews)
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(400);
+            const resJson = JSON.parse(res.text);
+            resJson.should.be.an('array').to.have.lengthOf(1);
+            resJson[0].should.have.property('status').equal("Le paramètre 'list_OPI' est requis.");
             done();
           });
       });
@@ -97,7 +122,10 @@ describe('Cache', () => {
           .query({ idCache })
           .end((err, res) => {
             should.not.exist(err);
-            res.should.have.status(406);
+            res.should.have.status(400);
+            const resJson = JSON.parse(res.text);
+            resJson.should.be.an('array').to.have.lengthOf(1);
+            resJson[0].should.have.property('status').equal("Le paramètre 'idCache' n'est pas valide.");
             done();
           });
       });

--- a/regress/3_graph.js
+++ b/regress/3_graph.js
@@ -172,18 +172,22 @@ describe('Graph', () => {
           });
       });
     });
-    // describe('query: x=230747 & y=6759643', () => {
-    //   // branch doesn't exist
-    //   it("should return a 'branch does not exist'", (done) => {
-    //     chai.request(app)
-    //       .get('/12/graph')
-    //       .query({ x: 230747, y: 6759643 })
-    //       .end((err, res) => {
-    //         should.not.exist(err);
-    //         res.should.have.status(400); done();
-    //       });
-    //   });
-    // });
+    describe('query: x=230747 & y=6759643', () => {
+      // branch doesn't exist
+      it("idBranch=99999 => should return a 'branch does not exist'", (done) => {
+        chai.request(app)
+          .get('/99999/graph')
+          .query({ x: 230747, y: 6759643 })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(400);
+            const resJson = JSON.parse(res.text);
+            resJson.should.be.an('array').to.have.lengthOf(1);
+            resJson[0].should.have.property('status').equal("Le paramètre 'idBranch' n'est pas valide.");
+            done();
+          });
+      });
+    });
   });
 
   describe('delete the test cache', () => {

--- a/regress/4_wmts.js
+++ b/regress/4_wmts.js
@@ -77,7 +77,8 @@ describe('Wmts', () => {
           should.not.exist(err);
           res.should.have.status(400);
           const resJson = JSON.parse(res.text);
-          resJson.should.have.property('status').equal("'OTHER': unsupported SERVICE value");
+          resJson.should.be.an('array').to.have.lengthOf(1);
+          resJson[0].should.have.property('status').equal("'OTHER': unsupported SERVICE value");
           done();
         });
     });
@@ -92,7 +93,8 @@ describe('Wmts', () => {
           should.not.exist(err);
           res.should.have.status(400);
           const resJson = JSON.parse(res.text);
-          resJson.should.have.property('status').equal("'Other': unsupported REQUEST value");
+          resJson.should.be.an('array').to.have.lengthOf(1);
+          resJson[0].should.have.property('status').equal("'Other': unsupported REQUEST value");
           done();
         });
     });
@@ -125,7 +127,8 @@ describe('Wmts', () => {
           should.not.exist(err);
           res.should.have.status(400);
           const resJson = JSON.parse(res.text);
-          resJson.should.have.property('status').equal("'image/autre': unsupported FORMAT value");
+          resJson.should.be.an('array').to.have.lengthOf(1);
+          resJson[0].should.have.property('status').equal("'image/autre': unsupported FORMAT value");
           done();
         });
     });
@@ -264,7 +267,8 @@ describe('Wmts', () => {
             should.not.exist(err);
             res.should.have.status(400);
             const resJson = JSON.parse(res.text);
-            resJson.should.have.property('status').equal("'other': unsupported LAYER value");
+            resJson.should.be.an('array').to.have.lengthOf(1);
+            resJson[0].should.have.property('status').equal("'other': unsupported LAYER value");
             done();
           });
       });
@@ -291,39 +295,41 @@ describe('Wmts', () => {
             should.not.exist(err);
             res.should.have.status(400);
             const resJson = JSON.parse(res.text);
-            resJson.should.have.property('status').equal("'other': unsupported STYLE value");
+            resJson.should.be.an('array').to.have.lengthOf(1);
+            resJson[0].should.have.property('status').equal("'other': unsupported STYLE value");
             done();
           });
       });
     });
-    // describe('query: TILEMATRIXSET=OTHER', () => {
-    //   it('should return an error', (done) => {
-    //     chai.request(app)
-    //       .get(`/${idBranch}/wmts`)
-    //       .query({
-    //         SERVICE: 'WMTS',
-    //         REQUEST: 'GetFeatureInfo',
-    //         VERSION: '1.0.0',
-    //         LAYER: 'ortho',
-    //         STYLE: 'normal',
-    //         INFOFORMAT: 'application/gml+xml; version=3.1',
-    //         TILEMATRIXSET: 'Other_Xcm',
-    //         TILEMATRIX: 21,
-    //         TILEROW: 34395,
-    //         TILECOL: 18027,
-    //         I: 139,
-    //         J: 102,
-    //       })
-    //       .end((err, res) => {
-    //         should.not.exist(err);
-    //         res.should.have.status(400);
-    //         const resJson = JSON.parse(res.text);
-    //         resJson.should.have.property('status')
-    //           .equal("'Other_Xcm': unsupported TILEMATRIXSET value");
-    //         done();
-    //       });
-    //   });
-    // });
+    describe('query: TILEMATRIXSET=OTHER', () => {
+      it('should return an error', (done) => {
+        chai.request(app)
+          .get(`/${idBranch}/wmts`)
+          .query({
+            SERVICE: 'WMTS',
+            REQUEST: 'GetFeatureInfo',
+            VERSION: '1.0.0',
+            LAYER: 'ortho',
+            STYLE: 'normal',
+            INFOFORMAT: 'application/gml+xml; version=3.1',
+            TILEMATRIXSET: 'Other_Xcm',
+            TILEMATRIX: 21,
+            TILEROW: 34395,
+            TILECOL: 18027,
+            I: 139,
+            J: 102,
+          })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.should.have.status(400);
+            const resJson = JSON.parse(res.text);
+            resJson.should.be.an('array').to.have.lengthOf(1);
+            resJson[0].should.have.property('status')
+              .equal("'Other_Xcm': unsupported TILEMATRIXSET value");
+            done();
+          });
+      });
+    });
     it('should return an xml', (done) => {
       chai.request(app)
         .get(`/${idBranch}/wmts`)
@@ -394,7 +400,7 @@ describe('Wmts', () => {
           should.not.exist(err);
           res.should.have.status(400);
           const resJson = JSON.parse(res.text);
-          resJson.should.have.property('msg').equal('out of bounds');
+          resJson.should.have.property('status').equal('out of bounds');
 
           done();
         });

--- a/routes/cache.js
+++ b/routes/cache.js
@@ -87,14 +87,15 @@ router.post('/cache',
   returnMsg);
 
 router.delete('/cache',
+  pgClient.open,
+  cache.getCaches.bind({ column: 'id' }),
   [
     query('idCache')
       .exists().withMessage(createErrMsg.missingParameter('idCache'))
-      .isInt({ min: 0 })
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
       .withMessage(createErrMsg.invalidParameter('idCache')),
   ],
   validateParams,
-  pgClient.open,
   cache.deleteCache,
   pgClient.close,
   returnMsg);

--- a/routes/cache.js
+++ b/routes/cache.js
@@ -8,6 +8,63 @@ const cache = require('../middlewares/cache');
 const pgClient = require('../middlewares/pgClient');
 const returnMsg = require('../middlewares/returnMsg');
 
+const overviews = [
+  body('overviews')
+    .exists().withMessage(createErrMsg.missingBody),
+  body('overviews.identifier')
+    .exists().withMessage(createErrMsg.missingParameter('identifier')),
+  body('overviews.list_OPI')
+    .exists().withMessage(createErrMsg.missingParameter('list_OPI')),
+  body('overviews.crs')
+    .exists().withMessage(createErrMsg.missingParameter('crs')),
+  body('overviews.crs.type')
+    .exists().withMessage(createErrMsg.missingParameter('crs.type')),
+  body('overviews.crs.code')
+    .exists().withMessage(createErrMsg.missingParameter('crs.code')),
+  body('overviews.crs.boundingBox')
+    .exists().withMessage(createErrMsg.missingParameter('crs.boundingBox')),
+  body('overviews.crs.boundingBox.xmin')
+    .exists().withMessage(createErrMsg.missingParameter('crs.boundingBox.xmin')),
+  body('overviews.crs.boundingBox.xmax')
+    .exists().withMessage(createErrMsg.missingParameter('crs.boundingBox.xmax')),
+  body('overviews.crs.boundingBox.ymin')
+    .exists().withMessage(createErrMsg.missingParameter('crs.boundingBox.ymin')),
+  body('overviews.crs.boundingBox.ymax')
+    .exists().withMessage(createErrMsg.missingParameter('crs.boundingBox.ymax')),
+  body('overviews.crs.proj4Definition')
+    .exists().withMessage(createErrMsg.missingParameter('crs.proj4Definition')),
+  body('overviews.resolution')
+    .exists().withMessage(createErrMsg.missingParameter('resolution')),
+  body('overviews.level')
+    .exists().withMessage(createErrMsg.missingParameter('level')),
+  // body('overviews.level.min')
+  //   .exists().withMessage(createErrMsg.missingParameter('level.min')),
+  body('overviews.level.max')
+    .exists().withMessage(createErrMsg.missingParameter('level.max')),
+  body('overviews.tileSize')
+    .exists().withMessage(createErrMsg.missingParameter('tileSize')),
+  body('overviews.tileSize.width')
+    .exists().withMessage(createErrMsg.missingParameter('tileSize.width')),
+  body('overviews.tileSize.height')
+    .exists().withMessage(createErrMsg.missingParameter('tileSize.height')),
+  body('overviews.slabSize')
+    .exists().withMessage(createErrMsg.missingParameter('slabSize')),
+  body('overviews.slabSize.width')
+    .exists().withMessage(createErrMsg.missingParameter('slabSize.width')),
+  body('overviews.slabSize.height')
+    .exists().withMessage(createErrMsg.missingParameter('slabSize.height')),
+  body('overviews.dataSet')
+    .exists().withMessage(createErrMsg.missingParameter('dataSet')),
+  body('overviews.dataSet.boundingBox')
+    .exists().withMessage(createErrMsg.missingParameter('dataSet.boundingBox')),
+  body('overviews.dataSet.boundingBox.LowerCorner')
+    .exists().withMessage(createErrMsg.missingParameter('dataSet.boundingBox.LowerCorner')),
+  body('overviews.dataSet.boundingBox.UpperCorner')
+    .exists().withMessage(createErrMsg.missingParameter('dataSet.boundingBox.UpperCorner')),
+  body('overviews.dataSet.limits')
+    .exists().withMessage(createErrMsg.missingParameter('dataSet.limits')),
+];
+
 router.get('/caches',
   pgClient.open,
   cache.getCaches,
@@ -21,10 +78,7 @@ router.post('/cache',
       .exists().withMessage(createErrMsg.missingParameter('name')),
     query('path')
       .exists().withMessage(createErrMsg.missingParameter('path')),
-    body('overviews')
-      .exists().withMessage(createErrMsg.missingBody),
-    body('overviews.list_OPI')
-      .exists().withMessage(createErrMsg.missingParameter('list_OPI')),
+    ...overviews,
   ],
   validateParams,
   pgClient.open,

--- a/routes/file.js
+++ b/routes/file.js
@@ -6,10 +6,11 @@ const fs = require('fs');
 
 const validateParams = require('../paramValidation/validateParams');
 const createErrMsg = require('../paramValidation/createErrMsg');
+const returnMsg = require('../middlewares/returnMsg');
 
 router.get('/json/:typefile', [
   param('typefile')
-    .exists().withMessage(createErrMsg.missingParameter('typefile'))
+    // .exists().withMessage(createErrMsg.missingParameter('typefile'))
     .isIn(['overviews', 'test'])
     .withMessage(createErrMsg.invalidParameter('typefile')),
   query('cachePath')
@@ -64,6 +65,7 @@ async (req, res, next) => {
     debug(' => Erreur');
     res.status(err.code).send(err.msg);
   }
-});
+},
+returnMsg);
 
 module.exports = router;

--- a/routes/graph.js
+++ b/routes/graph.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 const { query, param } = require('express-validator');
+const cache = require('../middlewares/cache');
 const branch = require('../middlewares/branch');
 
 const validateParams = require('../paramValidation/validateParams');
@@ -8,26 +9,28 @@ const graph = require('../middlewares/graph');
 const pgClient = require('../middlewares/pgClient');
 const returnMsg = require('../middlewares/returnMsg');
 
-router.get('/:idBranch/graph', [
-  param('idBranch')
-    .exists().withMessage(createErrMsg.missingParameter('idBranch'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('idBranch')),
-  query('x')
-    .exists().withMessage(createErrMsg.missingParameter('x'))
-    .matches(/^\d+(.\d+)?$/i)
-    .withMessage(createErrMsg.invalidParameter('x')),
-  query('y')
-    .exists().withMessage(createErrMsg.missingParameter('y'))
-    .matches(/^\d+(.\d+)?$/i)
-    .withMessage(createErrMsg.invalidParameter('y')),
-],
-validateParams,
-pgClient.open,
-branch.validBranch,
-branch.getOverviews,
-graph.getGraph,
-pgClient.close,
-returnMsg);
+router.get('/:idBranch/graph',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  [
+    param('idBranch')
+      .exists().withMessage(createErrMsg.missingParameter('idBranch'))
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
+      .withMessage(createErrMsg.invalidParameter('idBranch')),
+    query('x')
+      .exists().withMessage(createErrMsg.missingParameter('x'))
+      .matches(/^\d+(.\d+)?$/i)
+      .withMessage(createErrMsg.invalidParameter('x')),
+    query('y')
+      .exists().withMessage(createErrMsg.missingParameter('y'))
+      .matches(/^\d+(.\d+)?$/i)
+      .withMessage(createErrMsg.invalidParameter('y')),
+  ],
+  validateParams,
+  cache.getCachePath,
+  cache.getOverviews,
+  graph.getGraph,
+  pgClient.close,
+  returnMsg);
 
 module.exports = router;

--- a/routes/patch.js
+++ b/routes/patch.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const { body, param } = require('express-validator');
 const GJV = require('geojson-validation');
+const cache = require('../middlewares/cache');
 const branch = require('../middlewares/branch');
 const validator = require('../paramValidation/validator');
 const validateParams = require('../paramValidation/validateParams');
@@ -36,76 +37,85 @@ const geoJsonAPatcher = [
     .withMessage(createErrMsg.invalidParameter('properties.cliche')),
 ];
 
-router.get('/:idBranch/patches', [
-  param('idBranch')
-    .exists().withMessage(createErrMsg.missingParameter('idBranch'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('idBranch')),
-],
-validateParams,
-pgClient.open,
-branch.validBranch,
-patch.getPatches,
-pgClient.close,
-returnMsg);
-
-router.post('/:idBranch/patch',
-  patch.encapBody.bind({ keyName: 'geoJSON' }),
+router.get('/:idBranch/patches',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
   [
     param('idBranch')
       .exists().withMessage(createErrMsg.missingParameter('idBranch'))
-      .isInt({ min: 0 })
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
+      .withMessage(createErrMsg.invalidParameter('idBranch')),
+  ],
+  validateParams,
+  cache.getCachePath,
+  patch.getPatches,
+  pgClient.close,
+  returnMsg);
+
+router.post('/:idBranch/patch',
+  patch.encapBody.bind({ keyName: 'geoJSON' }),
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  [
+    param('idBranch')
+      .exists().withMessage(createErrMsg.missingParameter('idBranch'))
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
       .withMessage(createErrMsg.invalidParameter('idBranch')),
     ...geoJsonAPatcher,
   ],
   validateParams,
-  pgClient.open,
-  branch.validBranch,
-  branch.getOverviews,
+  cache.getCachePath,
+  cache.getOverviews,
   patch.postPatch,
   pgClient.close,
   returnMsg);
 
-router.put('/:idBranch/patch/undo', [
-  param('idBranch')
-    .exists().withMessage(createErrMsg.missingParameter('idBranch'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('idBranch')),
-],
-validateParams,
-pgClient.open,
-branch.validBranch,
-branch.getOverviews,
-patch.undo,
-pgClient.close,
-returnMsg);
+router.put('/:idBranch/patch/undo',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  [
+    param('idBranch')
+      .exists().withMessage(createErrMsg.missingParameter('idBranch'))
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
+      .withMessage(createErrMsg.invalidParameter('idBranch')),
+  ],
+  validateParams,
+  cache.getCachePath,
+  cache.getOverviews,
+  patch.undo,
+  pgClient.close,
+  returnMsg);
 
-router.put('/:idBranch/patch/redo', [
-  param('idBranch')
-    .exists().withMessage(createErrMsg.missingParameter('idBranch'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('idBranch')),
-],
-validateParams,
-pgClient.open,
-branch.validBranch,
-branch.getOverviews,
-patch.redo,
-pgClient.close,
-returnMsg);
+router.put('/:idBranch/patch/redo',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  [
+    param('idBranch')
+      .exists().withMessage(createErrMsg.missingParameter('idBranch'))
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
+      .withMessage(createErrMsg.invalidParameter('idBranch')),
+  ],
+  validateParams,
+  cache.getCachePath,
+  cache.getOverviews,
+  patch.redo,
+  pgClient.close,
+  returnMsg);
 
-router.put('/:idBranch/patches/clear', [
-  param('idBranch')
-    .exists().withMessage(createErrMsg.missingParameter('idBranch'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('idBranch')),
-],
-validateParams,
-pgClient.open,
-branch.validBranch,
-branch.getOverviews,
-patch.clear,
-pgClient.close,
-returnMsg);
+router.put('/:idBranch/patches/clear',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  [
+    param('idBranch')
+      .exists().withMessage(createErrMsg.missingParameter('idBranch'))
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
+      .withMessage(createErrMsg.invalidParameter('idBranch')),
+  ],
+  validateParams,
+  cache.getCachePath,
+  cache.getOverviews,
+  patch.clear,
+  pgClient.close,
+  returnMsg);
 
 module.exports = router;

--- a/routes/wmts.js
+++ b/routes/wmts.js
@@ -3,6 +3,7 @@ const { query, param } = require('express-validator');
 
 const validateParams = require('../paramValidation/validateParams');
 const createErrMsg = require('../paramValidation/createErrMsg');
+const cache = require('../middlewares/cache');
 const branch = require('../middlewares/branch');
 const wmts = require('../middlewares/wmts');
 const pgClient = require('../middlewares/pgClient');
@@ -19,76 +20,83 @@ router.use((req, _res, next) => {
   next();
 });
 
-router.get('/:idBranch/wmts', [
-  param('idBranch')
-    .exists().withMessage(createErrMsg.missingParameter('idBranch'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('idBranch')),
-  query('SERVICE')
-    .exists().withMessage(createErrMsg.missingParameter('SERVICE'))
-    .isIn(['WMTS', 'WMS'])
-    .withMessage((SERVICE) => (`'${SERVICE}': unsupported SERVICE value`)),
-  query('REQUEST')
-    .exists().withMessage(createErrMsg.missingParameter('REQUEST'))
-    .isIn(['GetCapabilities', 'GetTile', 'GetFeatureInfo'])
-    .withMessage((REQUEST) => (`'${REQUEST}': unsupported REQUEST value`)),
-  query('VERSION')
-    .if(query('SERVICE').isIn(['WMTS']))
-    .if(query('REQUEST').isIn(['GetCapabilities']))
-    .exists()
-    .withMessage(createErrMsg.missingParameter('VERSION'))
-    .matches(/^\d+(.\d+)*$/i)
-    .withMessage(createErrMsg.invalidParameter('VERSION'))
-    .if(query('SERVICE').isIn(['WMS', 'WMTS']))
-    .if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
-    .exists()
-    .withMessage(createErrMsg.missingParameter('VERSION'))
-    .matches(/^\d+(.\d+)*$/i)
-    .withMessage(createErrMsg.invalidParameter('VERSION')),
-  query('LAYER').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
-    .exists().withMessage(createErrMsg.missingParameter('LAYER'))
-    .isIn(['ortho', 'graph', 'opi'])
-    .withMessage((LAYER) => (`'${LAYER}': unsupported LAYER value`)),
-  query('Name').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo'])).if(query('LAYER').isIn(['opi']))
-    .exists()
-    .withMessage(createErrMsg.missingParameter('Name'))
-    .optional(),
-  query('STYLE').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
-    .exists().withMessage(createErrMsg.missingParameter('STYLE'))
-    .isIn(['normal'])
-    .withMessage((STYLE) => (`'${STYLE}': unsupported STYLE value`)),
-  query('FORMAT').if(query('REQUEST').isIn(['GetTile'])).exists().withMessage(createErrMsg.missingParameter('FORMAT'))
-    .isIn(['image/png', 'image/jpeg'])
-    .withMessage((FORMAT) => (`'${FORMAT}': unsupported FORMAT value`)),
-  query('INFOFORMAT').if(query('REQUEST').isIn(['GetFeatureInfo'])).exists().withMessage(createErrMsg.missingParameter('INFOFORMAT')),
-  query('TILEMATRIXSET').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
-    .exists().withMessage(createErrMsg.missingParameter('TILEMATRIXSET'))
-    // .custom((TILEMATRIXSET, { req }) => TILEMATRIXSET === req.app.overviews.identifier)
-    .withMessage((TILEMATRIXSET) => (`'${TILEMATRIXSET}': unsupported TILEMATRIXSET value`)),
-  query('TILEMATRIX').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo'])).exists().withMessage(createErrMsg.missingParameter('TILEMATRIX')),
-  query('TILEROW').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
-    .exists().withMessage(createErrMsg.missingParameter('TILEROW'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('TILEROW')),
-  query('TILECOL').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
-    .exists().withMessage(createErrMsg.missingParameter('TILECOL'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('TILECOL')),
-  query('I').if(query('REQUEST').isIn(['GetFeatureInfo']))
-    .exists().withMessage(createErrMsg.missingParameter('I'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('I')),
-  query('J').if(query('REQUEST').isIn(['GetFeatureInfo']))
-    .exists().withMessage(createErrMsg.missingParameter('J'))
-    .isInt({ min: 0 })
-    .withMessage(createErrMsg.invalidParameter('J')),
-],
-validateParams,
-pgClient.open,
-branch.validBranch,
-branch.getOverviews,
-wmts.wmts,
-pgClient.close,
-returnMsg);
+router.get('/:idBranch/wmts',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  [
+    param('idBranch')
+      .exists().withMessage(createErrMsg.missingParameter('idBranch'))
+      .custom((value, { req }) => req.result.json.includes(Number(value)))
+      .withMessage(createErrMsg.invalidParameter('idBranch')),
+    query('SERVICE')
+      .exists().withMessage(createErrMsg.missingParameter('SERVICE'))
+      .isIn(['WMTS', 'WMS'])
+      .withMessage((SERVICE) => (`'${SERVICE}': unsupported SERVICE value`)),
+    query('REQUEST')
+      .exists().withMessage(createErrMsg.missingParameter('REQUEST'))
+      .isIn(['GetCapabilities', 'GetTile', 'GetFeatureInfo'])
+      .withMessage((REQUEST) => (`'${REQUEST}': unsupported REQUEST value`)),
+    query('VERSION')
+      .if(query('SERVICE').isIn(['WMTS']))
+      .if(query('REQUEST').isIn(['GetCapabilities']))
+      .exists()
+      .withMessage(createErrMsg.missingParameter('VERSION'))
+      .matches(/^\d+(.\d+)*$/i)
+      .withMessage(createErrMsg.invalidParameter('VERSION'))
+      .if(query('SERVICE').isIn(['WMS', 'WMTS']))
+      .if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
+      .exists()
+      .withMessage(createErrMsg.missingParameter('VERSION'))
+      .matches(/^\d+(.\d+)*$/i)
+      .withMessage(createErrMsg.invalidParameter('VERSION')),
+    query('LAYER').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
+      .exists().withMessage(createErrMsg.missingParameter('LAYER'))
+      .isIn(['ortho', 'graph', 'opi'])
+      .withMessage((LAYER) => (`'${LAYER}': unsupported LAYER value`)),
+    query('Name').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo'])).if(query('LAYER').isIn(['opi']))
+      .exists()
+      .withMessage(createErrMsg.missingParameter('Name'))
+      .optional(),
+    query('STYLE').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
+      .exists().withMessage(createErrMsg.missingParameter('STYLE'))
+      .isIn(['normal'])
+      .withMessage((STYLE) => (`'${STYLE}': unsupported STYLE value`)),
+    query('FORMAT').if(query('REQUEST').isIn(['GetTile'])).exists().withMessage(createErrMsg.missingParameter('FORMAT'))
+      .isIn(['image/png', 'image/jpeg'])
+      .withMessage((FORMAT) => (`'${FORMAT}': unsupported FORMAT value`)),
+    query('INFOFORMAT').if(query('REQUEST').isIn(['GetFeatureInfo'])).exists().withMessage(createErrMsg.missingParameter('INFOFORMAT')),
+  ],
+  validateParams,
+  cache.getCachePath,
+  cache.getOverviews,
+  [
+    query('TILEMATRIXSET').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
+      .exists().withMessage(createErrMsg.missingParameter('TILEMATRIXSET'))
+      .custom((TILEMATRIXSET, { req }) => TILEMATRIXSET === req.overviews.identifier)
+      .withMessage((TILEMATRIXSET) => (`'${TILEMATRIXSET}': unsupported TILEMATRIXSET value`)),
+    query('TILEMATRIX').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo'])).exists().withMessage(createErrMsg.missingParameter('TILEMATRIX')),
+    query('TILEROW').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
+      .exists().withMessage(createErrMsg.missingParameter('TILEROW'))
+      .isInt({ min: 0 })
+      .withMessage(createErrMsg.invalidParameter('TILEROW')),
+    query('TILECOL').if(query('REQUEST').isIn(['GetTile', 'GetFeatureInfo']))
+      .exists().withMessage(createErrMsg.missingParameter('TILECOL'))
+      .isInt({ min: 0 })
+      .withMessage(createErrMsg.invalidParameter('TILECOL')),
+    query('I').if(query('REQUEST').isIn(['GetFeatureInfo']))
+      .exists().withMessage(createErrMsg.missingParameter('I'))
+      .isInt({ min: 0 })
+      .withMessage(createErrMsg.invalidParameter('I')),
+    query('J').if(query('REQUEST').isIn(['GetFeatureInfo']))
+      .exists().withMessage(createErrMsg.missingParameter('J'))
+      .isInt({ min: 0 })
+      .withMessage(createErrMsg.invalidParameter('J')),
+  ],
+  validateParams,
+  // cache.getCachePath,
+  // cache.getOverviews,
+  wmts.wmts,
+  pgClient.close,
+  returnMsg);
 
 module.exports = router;


### PR DESCRIPTION
Objectifs :
- utiliser le fait que l'attribut num d'un patch est automatiquement attribué par la base de données (ne plus avoir a le renseigné au niveau de l'API)
- Augmenter la couverture des tests de non régression

Modifications :
- Suppression de la variable num lors de l'insert d'un patch
- correction de message de debug dans db.js
- ajout Validation param pour le fichier overviews
- Fix de la route GET file
- Modification de la gestion des erreurs du ValideParam
- Modification du SQL GET caches et GET branches pour que la liste soit ordonnée
- Ajout de test de non régression
- lancer les tests coveralls pour toutes PR et non seulement pour une PR vers master