### PR TITLE
fix(cache): use 5 levels for 2nd layer of COGs

### DIFF
--- a/ressources/LAMB93_20cm.json
+++ b/ressources/LAMB93_20cm.json
@@ -13,7 +13,7 @@
 	},
 	"resolution": 0.20,
 	"level": {
-		"min": 12,
+		"min": 10,
 		"max": 19
 	},
 	"tileSize": {

--- a/ressources/LAMB93_5cm.json
+++ b/ressources/LAMB93_5cm.json
@@ -13,7 +13,7 @@
 	},
 	"resolution": 0.05,
 	"level": {
-		"min": 14,
+		"min": 12,
 		"max": 21
 	},
 	"tileSize": {


### PR DESCRIPTION
Correctoin du calcul du cache, seulement 8 niveaux étaient calculés avec deux couches de COGs (10 niveaux possibles)