### PR TITLE
fix(cache): fix boundingBox update

### DIFF
--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -54,10 +54,10 @@ def get_slabbox(input_filename, overviews, slab_change):
             = min(tile_limits['LowerCorner'][1],
                   overviews['dataSet']['boundingBox']['LowerCorner'][1])
         overviews['dataSet']['boundingBox']['UpperCorner'][0]\
-            = max(tile_limits['LowerCorner'][0],
+            = max(tile_limits['UpperCorner'][0],
                   overviews['dataSet']['boundingBox']['UpperCorner'][0])
         overviews['dataSet']['boundingBox']['UpperCorner'][1]\
-            = max(tile_limits['LowerCorner'][1],
+            = max(tile_limits['UpperCorner'][1],
                   overviews['dataSet']['boundingBox']['UpperCorner'][1])
 
     for slab_z in range(overviews['dataSet']['level']['min'],


### PR DESCRIPTION
# Motivation

La mise à jour de la boundingBox du cache est fausse, cela conduit à un mauvais GetCapabilities et à des problèmes de prise en compte de l'emprise du flux dans QGis et lors de l'utilisation de gdal pour des exports raster.

# Correction

Erreur de copie/coller entre LowerCorner et UpperCorner