### PR TITLE
feat(API): add slabs in patches GeoJson export

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -145,11 +145,13 @@ async function getActivePatches(pgClient, idBranch) {
     debug(`~~getActivePatches (idBranch: ${idBranch})`);
 
     const sql = "SELECT json_build_object('type', 'FeatureCollection', "
-    + "'features', json_agg(ST_AsGeoJSON(t.*)::json)) FROM "
-    + '(SELECT p.*, ARRAY_AGG(s.x) as x, ARRAY_AGG(s.y) as y, ARRAY_AGG(s.z) as z '
+    + "'features', json_agg(ST_AsGeoJSON(s.*)::json)) FROM "
+    + '(SELECT t.*, o.name as cliche, o.color FROM '
+    + '(SELECT p.*, ARRAY_AGG(ARRAY[s.x, s.y, s.z]) as slabs '
     + 'FROM patches p LEFT JOIN slabs s ON p.id = s.id_patch WHERE p.id_branch = $1 '
     + 'AND p.active=True '
-    + 'GROUP BY p.id ORDER BY p.num) as t';
+    + 'GROUP BY p.id ORDER BY p.num) as t, opi o '
+    + 'WHERE t.id_opi = o.id) as s';
 
     debug(sql);
 
@@ -172,11 +174,13 @@ async function getUnactivePatches(pgClient, idBranch) {
     debug(`~~getUnactivePatches (idBranch: ${idBranch})`);
 
     const sql = "SELECT json_build_object('type', 'FeatureCollection', "
-    + "'features', json_agg(ST_AsGeoJSON(t.*)::json)) FROM "
-    + '(SELECT p.*, ARRAY_AGG(s.x) as x, ARRAY_AGG(s.y) as y, ARRAY_AGG(s.z) as z '
+    + "'features', json_agg(ST_AsGeoJSON(s.*)::json)) FROM "
+    + '(SELECT t.*, o.name as cliche, o.color FROM '
+    + '(SELECT p.*, ARRAY_AGG(ARRAY[s.x, s.y, s.z]) as slabs '
     + 'FROM patches p LEFT JOIN slabs s ON p.id = s.id_patch WHERE p.id_branch = $1 '
     + 'AND p.active=False '
-    + 'GROUP BY p.id ORDER BY p.num) as t';
+    + 'GROUP BY p.id ORDER BY p.num) as t, opi o '
+    + 'WHERE t.id_opi = o.id) as s';
 
     debug(sql);
 

--- a/middlewares/patch.js
+++ b/middlewares/patch.js
@@ -613,22 +613,9 @@ async function clear(req, _res, next) {
   }
   const { features } = activePatches;
   const slabsDico = {};
-  // features.forEach((feature) => {
-  //   feature.properties.slabs.forEach((item) => {
-  //     slabsDico[`${item.x}_${item.y}_${item.z}`] = item;
-  //   });
-  // });
-  features.forEach((feature, indexFeature) => {
-    feature.properties.x.forEach((item, indexSlab) => {
-      debug(features[indexFeature].properties.y[indexSlab]);
-      const x = item;
-      const y = features[indexFeature].properties.y[indexSlab];
-      const z = features[indexFeature].properties.z[indexSlab];
-      slabsDico[`${item}_${features[indexFeature].properties.y[indexSlab]}_${features[indexFeature].properties.z[indexSlab]}`] = {
-        x,
-        y,
-        z,
-      };
+  features.forEach((feature) => {
+    feature.properties.slabs.forEach((slab) => {
+      slabsDico[JSON.stringify(slab)] = { x: slab[0], y: slab[1], z: slab[2] };
     });
   });
   debug('', Object.keys(slabsDico).length, ' dalles impactées');


### PR DESCRIPTION
# Motivation

Améliorer l'export de la liste des dalles impactées dans les GeoJson.
Pour le moment on export 3 tableaux **x**, **y**, **z** alors qu'il serait préférable d'avoir un tableau **slabs** contenant des triplets [x,y,z]
