### PR TITLE
fix(monitor): do not display graph/contour for 2nd COG level

### DIFF
--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -191,7 +191,9 @@ class Viewer {
             format: 'image/png',
             name: layerName !== 'Contour' ? layerName.toLowerCase() : 'graph',
             tileMatrixSet: this.overviews.identifier,
-            tileMatrixSetLimits: this.overviews.dataSet.limits,
+            tileMatrixSetLimits:
+              (layerName === 'Contour') || (layerName === 'Graph')
+                ? this.overviews.dataSet.limitsForGraph : this.overviews.dataSet.limits,
           });
         } else if (layerList[layerName].type === 'vector') {
           layer.config.source = new itowns.FileSource({

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -72,6 +72,19 @@ async function main() {
 
     const overviews = await getOverviews;
 
+    // on ajoute les dataset.limits pour les layers graph/contour
+    // avec uniquement les niveaux correspondants au COG mis à jour par les patchs
+    // c'est-a-dire un seul niveau de COG
+    // on a donc besoin de connaitre le nombre de niveaux inclus dans un COG
+    const slabSize = Math.min(overviews.slabSize.width, overviews.slabSize.height);
+    const nbSubLevelsPerCOG = Math.floor(Math.log2(slabSize));
+    overviews.dataSet.limitsForGraph = {};
+    // on copie les limites des (nbSubLevelsPerCOG + 1) derniers niveaux
+    for (let l = overviews.dataSet.level.max - nbSubLevelsPerCOG;
+      l <= overviews.dataSet.level.max; l += 1) {
+      overviews.dataSet.limitsForGraph[l] = overviews.dataSet.limits[l];
+    }
+
     viewer.createView(overviews, activeCache.id);
     setupLoadingScreen(viewerDiv, viewer.view);
 


### PR DESCRIPTION
# Motivation

première partie du ticket #233 

# Principe

pour le moment pas de modification côté création du cache ou API, simplement on crée un dataSet.limitsForGraph avec uniquement les niveaux correspondant au COG réellement mis à jour.