### PR TITLE
feat(monitor): Escape key to unselect OPI

### DIFF
--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -11,11 +11,10 @@ const status = {
 };
 
 class Editing {
-  constructor(branch, layer, apiUrl) {
+  constructor(branch, apiUrl) {
     this.branch = branch;
     this.viewer = branch.viewer;
     this.view = this.viewer.view;
-    this.layer = layer;
     this.apiUrl = apiUrl;
 
     this.validClicheSelected = false;
@@ -131,6 +130,17 @@ class Editing {
   keydown(e) {
     if (this.currentStatus === status.WAITING) return;
     console.log(e.key, ' down');
+    if (this.currentStatus === status.RAS) {
+      // L'utilisateur demande à déselectionner l'OPI
+      if (this.validClicheSelected && (e.key === 'Escape')) {
+        this.validClicheSelected = false;
+        this.cliche = 'unknown';
+        this.controllers.cliche.__li.style.backgroundColor = '';
+        this.view.getLayerById('Opi').visible = false;
+        this.view.notifyChange(this.branch.layers.Opi, true);
+      }
+      return;
+    }
     if (e.key === 'Escape') {
       this.view.controls.setCursor('default', 'auto');
       this.cancelcurrentPolygon();
@@ -236,10 +246,11 @@ class Editing {
             }
             if (res.status === 201) {
               console.log('out of bounds');
-              this.layer.opi.colorLayer.visible = false;
+              this.cliche = 'unknown';
+              this.view.getLayerById('Opi').visible = false;
               this.validClicheSelected = false;
               this.controllers.cliche.__li.style.backgroundColor = '';
-              this.view.notifyChange(this.layer.opi.colorLayer, true);
+              this.view.notifyChange(this.branch.layers.Opi, true);
             }
             if (res.status === 202) {
               console.log('Server Error');

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -132,7 +132,7 @@ async function main() {
     branch.setLayers();
     viewer.refresh(branch.layers);
 
-    const editing = new Editing(branch, viewer.layer, apiUrl);
+    const editing = new Editing(branch, apiUrl);
     editing.cliche = 'unknown';
     editing.coord = `${viewer.xcenter.toFixed(2)},${viewer.ycenter.toFixed(2)}`;
     editing.color = [0, 0, 0];


### PR DESCRIPTION
# Motivation

Pouvoir déselectionner l'OPI pour revenir à un affichage sans la couche OPI.

# Principe

Utilisation de la touche **Escape**.
Au passage on a aussi corrigé un bug dans le cas où l'utilisateur sélectionne une OPI hors zone et on a supprimé un paramètre non utilisé dans le constructeur de **Editing**.