### PR TITLE
fix(API,monitor): npm vulnerabilities

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -26,6 +26,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v1

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -12,11 +12,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Use Node.js
-      uses: actions/setup-node@v1
+    - name: Use Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
       
     - name: API Install dependencies
-      run: npm install --dev
+      run: npm install --also=dev
         
     - name: API linter
       run: npm run lint

--- a/itowns/package-lock.json
+++ b/itowns/package-lock.json
@@ -50,9 +50,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -98,21 +98,41 @@
       "dev": true
     },
     "@loaders.gl/las": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/las/-/las-2.3.13.tgz",
-      "integrity": "sha512-wgr61zYaUo1kX53mci3BWuwyciaPT40Hblzo+mmYHvpb+sngD/OMQCD5EOP9LmPIdPX5K0WreKYpPuHWgtpekQ==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/las/-/las-3.0.12.tgz",
+      "integrity": "sha512-lX2ZforTUxvb3DiBlwJLENWJDPVT/PRj/q50tffbyr8GWIq86LOk/1B1hsFCw79f84fQGyzMxhcyM6HX02KxZw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "2.3.13"
+        "@loaders.gl/loader-utils": "3.0.12",
+        "@loaders.gl/schema": "3.0.12"
       }
     },
     "@loaders.gl/loader-utils": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-2.3.13.tgz",
-      "integrity": "sha512-vXzH5CWG8pWjUEb7hUr6CM4ERj4NVRpA60OxvVv/OaZZ7hNN63+9/tSUA5IXD9QArWPWrFBnKnvE+5gg4WNqTg==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.0.12.tgz",
+      "integrity": "sha512-J2cYU8d5mx/rDoKdl6SlvoyvO1PXNi6Upul1OGCDql7S/mq+M9afsvNmRraZJOzcoO5NuWq30Eoh3rWD2w5Mew==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@probe.gl/stats": "^3.3.0"
+        "@loaders.gl/worker-utils": "3.0.12",
+        "@probe.gl/stats": "^3.4.0"
+      }
+    },
+    "@loaders.gl/schema": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.0.12.tgz",
+      "integrity": "sha512-xJOi6s8SxPwuRfSyiSeUfuXHP5uRBsZOQfBvZTuU8XUyUn3d/nvk5VOZQgo44XTMmY3CqhfMUOFP3etC5oczsA==",
+      "requires": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": "^4.0.0",
+        "d3-dsv": "^1.2.0"
+      }
+    },
+    "@loaders.gl/worker-utils": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.0.12.tgz",
+      "integrity": "sha512-xbZiYxGNLniXrCMNyvyw91I+DCOrclHc3mwtCPZaJQi+eEFaq0Kh7Lv9yUCE6cCgDLNJfjcfmbcyCBgwlvq7WA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
       }
     },
     "@mapbox/jsonlint-lines-primitives": {
@@ -121,9 +141,9 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
-      "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.23.0.tgz",
+      "integrity": "sha512-zI26XoK0UjGOvOEUUAoKlmFKHrSD8qIMCaoQBsFxNPzGIluryT32Z1m4aq7NtxEsrfE+qc2mPPXQg+iRllqbqA==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -154,9 +174,9 @@
       }
     },
     "@probe.gl/stats": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.4.0.tgz",
-      "integrity": "sha512-Gl37r9qGuiKadIvTZdSZvzCNOttJYw6RcY1oT0oDuB8r2uhuZAdSMQRQTy9FTinp6MY6O9wngGnV6EpQ8wSBAw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.4.1.tgz",
+      "integrity": "sha512-1Ol5cH8MQqIrGNgU4NCBj2cw1qiXYfHP1QCFX+u/xyrvgwLkPrOGkdSYMzw4VKTjJzNae4i7urOTf2m2hduZzQ==",
       "requires": {
         "@babel/runtime": "^7.0.0"
       }
@@ -197,6 +217,16 @@
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
     },
+    "@types/flatbuffers": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.0.tgz",
+      "integrity": "sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA=="
+    },
+    "@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -224,6 +254,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
       "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==",
       "dev": true
+    },
+    "@types/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-AQ6zewa0ucLJvtUi5HsErbOFKAcQfRLt9zFLlUOvcXBy2G36a+ZDpCHSGdzJVUD8aNURtIjh9aSjCStNMRCcRQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -469,16 +504,15 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -501,6 +535,30 @@
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
+        }
+      }
+    },
+    "apache-arrow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-4.0.1.tgz",
+      "integrity": "sha512-DyF7GXCbSjsw4P5C8b+qW7OnJKa6w9mJI0mhV0+EfZbVZCmhfiF6ffqcnrI/kzBrRqn9hH/Ft9n5+m4DTbBJpg==",
+      "requires": {
+        "@types/flatbuffers": "^1.10.0",
+        "@types/node": "^14.14.37",
+        "@types/text-encoding-utf-8": "^1.0.1",
+        "command-line-args": "5.1.1",
+        "command-line-usage": "6.1.1",
+        "flatbuffers": "1.12.0",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "text-encoding-utf-8": "^1.0.2",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.17.33",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+          "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
         }
       }
     },
@@ -530,6 +588,11 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "array-flatten": {
       "version": "2.1.2",
@@ -1090,7 +1153,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1098,8 +1160,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorette": {
       "version": "1.3.0",
@@ -1107,11 +1168,59 @@
       "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1249,6 +1358,16 @@
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
+    "d3-dsv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
+      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
+      "requires": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      }
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -1291,6 +1410,11 @@
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2337,6 +2461,14 @@
         }
       }
     },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -2355,6 +2487,11 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
+    },
+    "flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="
     },
     "flatted": {
       "version": "3.2.2",
@@ -2542,8 +2679,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -3179,35 +3315,21 @@
       "dev": true
     },
     "itowns": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/itowns/-/itowns-2.34.0.tgz",
-      "integrity": "sha512-y7E15DMoB41BMh+ib8vabfK3h5+vA6hIrEHWNKpOUGoetmITSfosvfEba46l/h0OxZJ11l5iXe4p4kYxeBkAHA==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/itowns/-/itowns-2.35.0.tgz",
+      "integrity": "sha512-mf1Ak1iB24uipSqutRU05fg50IiJnX8A2kRoHGA9qzJutkA4HefA+VhgcMPOlBPwBYsLrIpAU0/mqJHeL0k70Q==",
       "requires": {
-        "@loaders.gl/las": "^2.3.13",
-        "@mapbox/mapbox-gl-style-spec": "^13.20.0",
+        "@loaders.gl/las": "^3.0.9",
+        "@mapbox/mapbox-gl-style-spec": "^13.21.0",
         "@mapbox/vector-tile": "^1.3.1",
-        "@tmcw/togeojson": "^4.4.1",
+        "@tmcw/togeojson": "^4.5.0",
         "@tweenjs/tween.js": "^18.6.4",
-        "earcut": "^2.2.2",
+        "earcut": "^2.2.3",
         "js-priority-queue": "^0.1.5",
         "pbf": "^3.2.1",
-        "regenerator-runtime": "^0.13.7",
-        "shpjs": "^3.6.3",
+        "regenerator-runtime": "^0.13.9",
+        "shpjs": "^4.0.2",
         "text-encoding-utf-8": "^1.0.2"
-      },
-      "dependencies": {
-        "shpjs": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-          "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
-          "requires": {
-            "jszip": "^2.4.0",
-            "lie": "^3.0.1",
-            "lru-cache": "^2.7.0",
-            "parsedbf": "^1.1.0",
-            "proj4": "^2.1.4"
-          }
-        }
       }
     },
     "jest-worker": {
@@ -3259,6 +3381,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha1-QRY7UENsdz2CQk28IO1w23YEuNc="
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3295,14 +3422,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      }
-    },
-    "jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
-      "requires": {
-        "pako": "~1.0.2"
       }
     },
     "killable": {
@@ -3376,6 +3495,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -3958,6 +4082,14 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "pad-left": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+      "integrity": "sha1-FuajstRKjhOMsIOMx8tAOk/J6ZQ=",
+      "requires": {
+        "repeat-string": "^1.5.4"
+      }
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -4171,9 +4303,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.2.tgz",
-      "integrity": "sha512-LPzSaBYp/TcbuSlpGwqT5jR9kvJ3Zp5ic2N5c2ybx6XB/lSfEHq2D7ja8AgoxHoMD91wXFALJoXsvshKPuXyew=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -4322,6 +4454,11 @@
         "resolve": "^1.9.0"
       }
     },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+    },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -4391,8 +4528,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -5251,7 +5387,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -5287,6 +5422,29 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
+        }
+      }
+    },
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
         }
       }
     },
@@ -5426,6 +5584,11 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5450,6 +5613,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -5988,6 +6156,22 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/itowns/package.json
+++ b/itowns/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "itowns": "^2.34.0",
+    "itowns": "^2.35.0",
     "proj4": "^2.7.5",
     "shpjs": "^4.0.2",
     "three": "^0.129.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2056,9 +2056,9 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -3605,9 +3605,9 @@
       }
     },
     "gdal-async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/gdal-async/-/gdal-async-3.2.3.tgz",
-      "integrity": "sha512-/57XyjSyYGtnYimPTMsBpqTUNBUg9jDuBhT6skSFXIBSCstQ+4liQDkbP4ahAa3cAeq+gOZhmNiklL4g/HVssg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/gdal-async/-/gdal-async-3.4.0.tgz",
+      "integrity": "sha512-uGMUPTCromSqr/jngixxg5udzsnZf+qiKaIjqf1i8uxy5nObX18/OCI7GtC3VcXzF7yKbHMENcfV+5QaW+XIeg==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.3",
         "nan": "^2.14.0"
@@ -3648,7 +3648,7 @@
           "bundled": true
         },
         "are-we-there-yet": {
-          "version": "1.1.5",
+          "version": "1.1.7",
           "bundled": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -3684,11 +3684,11 @@
           "bundled": true
         },
         "core-util-is": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true
         },
         "debug": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "bundled": true,
           "requires": {
             "ms": "2.1.2"
@@ -3728,7 +3728,7 @@
           }
         },
         "glob": {
-          "version": "7.1.7",
+          "version": "7.2.0",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3802,7 +3802,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.3",
+          "version": "3.1.5",
           "bundled": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -3825,8 +3825,11 @@
           "bundled": true
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "bundled": true
+          "version": "2.6.5",
+          "bundled": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
         },
         "nopt": {
           "version": "5.0.0",
@@ -3904,7 +3907,7 @@
           "bundled": true
         },
         "signal-exit": {
-          "version": "3.0.3",
+          "version": "3.0.5",
           "bundled": true
         },
         "string-width": {
@@ -3931,7 +3934,7 @@
           }
         },
         "tar": {
-          "version": "6.1.0",
+          "version": "6.1.11",
           "bundled": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -3942,15 +3945,31 @@
             "yallist": "^4.0.0"
           }
         },
+        "tr46": {
+          "version": "0.0.3",
+          "bundled": true
+        },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true
         },
-        "wide-align": {
-          "version": "1.1.3",
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "wrappy": {
@@ -4789,6 +4808,11 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -4804,10 +4828,23 @@
             }
           }
         },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         },
         "supports-color": {
           "version": "8.1.1",
@@ -4815,6 +4852,25 @@
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            }
           }
         },
         "yargs": {
@@ -6739,40 +6795,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "wkt-parser": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "express": "^4.17.1",
     "express-validator": "^6.12.1",
     "fs": "0.0.1-security",
-    "gdal-async": "3.2.3",
+    "gdal-async": "^3.4.0",
     "geojson-validation": "^1.0.2",
     "git-describe": "^4.1.0",
     "jimp": "^0.14.0",


### PR DESCRIPTION
# Motivation
Diminuer le nombre de vulnérabilités lors du npm install
 
# Démarche
Parmi les modifications importantes : 

* pour le moniteur itowns :    
  * passage à itowns 2.35 la dernière version stable, dernière release, à la place de 2.34
  * mise à jour des paquets
  => il reste 12 (9 modérées, 7 hautes), au lieu de 16 (9 modérées, 7 hautes) ; ce gain a été sans danger, mais corriger plus, c'est pas sans danger pour le bon fonctionnement ("breaking changes"), donc je pense que c'est déjà pas mal et qu'on verra plus tard

* pour l'API : 
  * passage au node 14, la dernière version stable, à la place du 10
  * mise à jour des paquets qui en découle
  => il reste 3 vulnérabilités (modérées), au lieu de 14 (9 modérées, 5 hautes)

