### PR TITLE
Gestion de couche d'alerte

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,17 +269,24 @@ A partir du client web en ajoutant le paramètre namecache={nom du cache en base
 A partir de l'interface web, on peut intégrer des couches vecteur (au format geojson ou shapefile) en les glissant directement dans la vue.
 Celle-ci est ensuite sauvegardée dans la base de données.
 
+Les paramètres d'affichage des couches ne sont pas persistants après un changement de branche de saisie ou de rafraîchissement de la page dans le navigateur.
+
 ### Gestion des couches d'alertes
 
-Pour naviguer à travers les entités d'une couche annexe prélablement ajoutée, il faut choisir cette couche dans le menu déroulant "alert".
+Pour naviguer à travers les entités d'une couche annexe prélablement ajoutée, il faut choisir cette couche dans le menu déroulant "Alerts Layer".
 A partir du moment où une couche a été selectionnée, le nombre d'entités déjà verifiées sur le nombre total s'affiche ainsi que les attributs propres à la première entité de la couche.
 On peut ensuite naviguer à travers les différentes entités en utilisant les flèches droite et gauche ou en cliquant directement sur l'entité voulue. Les champs "checked" et "comment" sont rafraichis avec les valeurs de l'entité selectionnée et peuvent être modifiés directement via le menu.
 Les flèches haut et bas proposent le même principe que droite et gauche avec pour seule différence de ne naviguer qu'à travers les entités non encore validées.
 
-### Retouches et patchs
+### Retouches
 
+Les étapes du processus de retouche du graphe de mosaïquage sont :
+* choisir la branche de saisie dans le menu déroulant "Active branch" (utiliser "Add new branch" pour créer une nouvelle branche)
+* choisir l'OPI de travail avec "Select an OPI"
+* démarrer la retouche ("Start polygon"), appuyer sur la touche "Majuscule" du clavier pour fermer la saisie
+* annuler ou refaire la retouche en utilisant les outils "undo", "redo"
 
-
+Les contours des retouches d'un chantier peuvent être affichés en activant l'option "visible" de la couche "Patches".
 
 ## Travailler à plusieurs sur un chantier
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,29 @@ Cette route prend en paramètre:
 - le chemin du dossier contenant les COG créé par le script **create_cache** et correspondant au cache à importer (ex: "cache_test"): soit en absolu, soit en relatif par rapport au dossier de lancement de l'API
 - le contenu du fichier **overviews.json** du cache à importer (celui qui a été créé par le script python et qui est à la racine du dossier contenant le cache à importer)
 
+## Traitement d'un chantier
+
+### Connection à un cache
+
+A partir du client web en ajoutant le paramètre namecache={nom du cache en base} (ex : "cache_test"), on peut visualiser le cache choisi et commencer à travailler dessus.
+
+### Import de couches vecteur annexes
+
+A partir de l'interface web, on peut intégrer des couches vecteur (au format geojson ou shapefile) en les glissant directement dans la vue.
+Celle-ci est ensuite sauvegardée dans la base de données.
+
+### Gestion des couches d'alertes
+
+Pour naviguer à travers les entités d'une couche annexe prélablement ajoutée, il faut choisir cette couche dans le menu déroulant "alert".
+A partir du moment où une couche a été selectionnée, le nombre d'entités déjà verifiées sur le nombre total s'affiche ainsi que les attributs propres à la première entité de la couche.
+On peut ensuite naviguer à travers les différentes entités en utilisant les flèches droite et gauche ou en cliquant directement sur l'entité voulue. Les champs "checked" et "comment" sont rafraichis avec les valeurs de l'entité selectionnée et peuvent être modifiés directement via le menu.
+Les flèches haut et bas proposent le même principe que droite et gauche avec pour seule différence de ne naviguer qu'à travers les entités non encore validées.
+
+### Retouches et patchs
+
+
+
+
 ## Travailler à plusieurs sur un chantier
 
 Il ne faut jamais travailler à plusieurs en même temps sur la même branche. Pour l'instant aucune vérification n'est faite au niveau de PackO et cela va conduire à des incohérences (un mécanisme de protection sera ajouté dès que possible).

--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -498,6 +498,53 @@ paths:
         '200':
           description: OK
 
+# Alerts
+  '/alert/{idFeature}?status={status}':
+    put:
+      tags:
+        - vector
+      summary: "Modification de l'attribut 'status' d'une feature donnée"
+      description: ""
+      parameters:
+        - in: path
+          name: idFeature
+          description: l'identifiant de la feature à modifier
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: status
+          description: nouvelle valeur
+          required: true
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+
+  '/alert/{idFeature}?comment={comment}':
+    put:
+      tags:
+        - vector
+      summary: "Modification de l'attribut 'comment' d'une feature donnée"
+      description: ""
+      parameters:
+        - in: path
+          name: idFeature
+          description: l'identifiant de la feature à modifier
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: comment
+          description: nouvelle valeur
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
 # WMTS
   '/{idBranch}/wmts':
     get:

--- a/itowns/Branch.js
+++ b/itowns/Branch.js
@@ -114,6 +114,7 @@ class Branch {
 
   createBranch() {
     this.viewer.message = '';
+    // eslint-disable-next-line no-alert
     const branchName = window.prompt('Choose a new branch name:', '');
     console.log(branchName);
     if (branchName === null) return;

--- a/itowns/Branch.js
+++ b/itowns/Branch.js
@@ -78,9 +78,6 @@ class Branch {
           point: {
             color: 'Yellow',
           },
-          fill: {
-            color: 'Yellow',
-          },
         },
       },
     };

--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -1,44 +1,60 @@
+/* eslint no-underscore-dangle: ["error", { "allow": [__controllers, __li, __select] }] */
+function getController(gui, name) {
+  let controller = null;
+  const controllers = gui.__controllers;
+  for (let i = 0; i < controllers.length; i += 1) {
+    const c = controllers[i];
+    if (c.property === name || c.name === name) {
+      controller = c;
+      break;
+    }
+  }
+  return controller;
+}
+
 class Controller {
   constructor(menuGlobe, editing) {
     this.controllers = {};
     this.menuGlobe = menuGlobe;
     this.editing = editing;
+    this.viewer = this.editing.viewer;
   }
 
-  setEditingController(name) {
-    if (this.controllers.polygon) {
-      this.controllers.polygon.remove();
-      delete this.controllers.polygon;
-    }
-    if (this.controllers.undo) {
-      this.controllers.undo.remove();
-      delete this.controllers.undo;
-    }
-    if (this.controllers.redo) {
-      this.controllers.redo.remove();
-      delete this.controllers.redo;
-    }
-    if (this.controllers.clear) {
-      this.controllers.clear.remove();
-      delete this.controllers.clear;
-    }
-    if (name !== 'orig') {
-      this.controllers.polygon = this.menuGlobe.gui.add(this.editing, 'polygon');
-      this.editing.controllers.polygon = this.controllers.polygon;
-      this.controllers.undo = this.menuGlobe.gui.add(this.editing, 'undo');
-      this.controllers.redo = this.menuGlobe.gui.add(this.editing, 'redo');
-      if (process.env.NODE_ENV === 'development') this.controllers.clear = this.menuGlobe.gui.add(this.editing, 'clear');
-    }
+  setEditingController() {
+    const brancheName = this.editing.branch.active.name;
+    this[brancheName !== 'orig' ? 'setVisible' : 'hide'](['polygon', 'undo', 'redo']);
+    if (process.env.NODE_ENV === 'development') this[brancheName !== 'orig' ? 'setVisible' : 'hide']('clear');
   }
 
-  refreshDropBox(list) {
+  refreshDropBox(dropBoxName, list) {
     let innerHTML = '';
     list.forEach((element) => {
       innerHTML += `<option value='${element}'>${element}</option>`;
     });
-    this.alert.domElement.children[0].innerHTML = innerHTML;
+    this[dropBoxName].domElement.children[0].innerHTML = innerHTML;
     // this.editing.alert = value;
-    this.alert.updateDisplay();
+    this[dropBoxName].updateDisplay();
+  }
+
+  resetAlerts() {
+    delete this.editing.alertLayerName;
+    delete this.viewer.alertLayerName;
+    this.alert.__select.options.selectedIndex = -1;
+    this.hide(['nbChecked', 'checked', 'comment']);
+  }
+
+  setVisible(controllerName) {
+    const controllers = (typeof controllerName === 'string' || controllerName instanceof String) ? [controllerName] : controllerName;
+    controllers.forEach((controller) => {
+      getController(this.viewer.menuGlobe.gui, controller).__li.style.display = '';
+    });
+  }
+
+  hide(controllerName) {
+    const controllers = (typeof controllerName === 'string' || controllerName instanceof String) ? [controllerName] : controllerName;
+    controllers.forEach((controller) => {
+      getController(this.viewer.menuGlobe.gui, controller).__li.style.display = 'none';
+    });
   }
 }
 export default Controller;

--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -30,5 +30,15 @@ class Controller {
       if (process.env.NODE_ENV === 'development') this.controllers.clear = this.menuGlobe.gui.add(this.editing, 'clear');
     }
   }
+
+  refreshDropBox(list) {
+    let innerHTML = '';
+    list.forEach((element) => {
+      innerHTML += `<option value='${element}'>${element}</option>`;
+    });
+    this.alert.domElement.children[0].innerHTML = innerHTML;
+    // this.editing.alert = value;
+    this.alert.updateDisplay();
+  }
 }
 export default Controller;

--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -176,7 +176,10 @@ class Editing {
       }),
       transparent: true,
       opacity: 0.7,
-      // zoom: { min: 10 },
+      zoom: {
+        min: this.viewer.zoomMin,
+        max: this.viewer.overviews.dataSet.level.max,
+      },
       style: new itowns.Style({
         // fill: {
         //   color: '#bbffbb',

--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -208,6 +208,7 @@ class Editing {
   async centerOnAlertFeature() {
     const layerTest = this.viewer.view.getLayerById(this.alertLayerName);
     const fc = await layerTest.source.loadData(undefined, layerTest);
+    this.nbChecked = `${fc.features[0].geometries.filter((elem) => elem.properties.status === true).length}/${fc.features[0].geometries.length}`;
     if (this.featureIndex === fc.features[0].geometries.length) this.featureIndex = 0;
     if (this.featureIndex === -1) this.featureIndex = fc.features[0].geometries.length - 1;
 

--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -11,6 +11,7 @@ const status = {
   POLYGON: 2,
   ENDING: 3,
   WAITING: 4,
+  COMMENT: 5,
 };
 
 class Editing {
@@ -26,6 +27,8 @@ class Editing {
     this.nbVertices = 0;
     this.lastPos = null;
     this.mousePosition = null;
+
+    this.STATUS = status;
   }
 
   pickPoint(event) {

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -35,14 +35,11 @@ else {
 `);
 
 function coloringAlerts(properties) {
+  // Pour le moment on utilise que 2 etats
   if (properties.status === false) {
-    // return color.set(0x5555ff);
-    return '#ff5555';
+    return '#ff5555';// red
   }
-  if (properties.status === true) {
-    return '#3cd25f';
-  }
-  return 'eeeeee';
+  return '#3cd25f';// green
 }
 
 class Viewer {
@@ -149,6 +146,8 @@ class Viewer {
   }
 
   centerCamera(coordX, coordY) {
+    // bug itowns...
+    // itowns.CameraUtils.animateCameraToLookAtTarget( ... )
     itowns.CameraUtils.transformCameraToLookAtTarget(
       this.view,
       this.view.camera.camera3D,

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -210,6 +210,10 @@ class Viewer {
             transparent,
             opacity,
             style,
+            zoom: {
+              min: source.isVectorSource ? this.zoomMin : this.overviews.dataSet.level.min,
+              max: this.overviews.dataSet.level.max,
+            },
           });
 
         if (layerName === 'Contour') {
@@ -248,6 +252,7 @@ class Viewer {
           //   layerList[layerName].style.point.color = coloringAlerts;
           // }
           layer.config.style = new itowns.Style(layerList[layerName].style);
+          layer.config.zoom = { min: this.zoomMin, max: this.overviews.dataSet.level.max };
         }
         layer.config.opacity = layerList[layerName].opacity;
         layer.colorLayer = new itowns.ColorLayer(

--- a/itowns/index.html
+++ b/itowns/index.html
@@ -35,6 +35,7 @@
     <!-- <div id="miniDiv"></div> -->
     <script src="node_modules/itowns/examples/js/GUI/GuiTools.js"></script>
     <script src="node_modules/itowns/examples/js/GUI/LoadingScreen.js"></script>
+    <script src="node_modules/itowns/examples/js/plugins/FeatureToolTip.js"></script>
     <!-- <script src="node_modules/itowns/dist/debug.js"></script> -->
     <script src="dist/bundle.js" type='module'></script>
 </body>

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -176,13 +176,6 @@ async function main() {
     editing.coord = `${viewer.xcenter.toFixed(2)},${viewer.ycenter.toFixed(2)}`;
     editing.color = [0, 0, 0];
 
-    // message
-    controllers.coord = viewer.menuGlobe.gui.add(editing, 'coord').name('Coordinates');
-    controllers.coord.listen();
-    viewer.message = '';
-    controllers.message = viewer.menuGlobe.gui.add(viewer, 'message').name('Message');
-    controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
-
     // const controllers = new Controller(viewer.menuGlobe, editing);
 
     // Gestion branche
@@ -202,9 +195,13 @@ async function main() {
     controllers.createBranch = viewer.menuGlobe.gui.add(branch, 'createBranch').name('Add new branch');
 
     // Selection OPI
+    controllers.select = viewer.menuGlobe.gui.add(editing, 'select').name('Select an OPI');
     controllers.cliche = viewer.menuGlobe.gui.add(editing, 'cliche').name('OPI selected');
     controllers.cliche.listen().domElement.parentElement.style.pointerEvents = 'none';
-    controllers.select = viewer.menuGlobe.gui.add(editing, 'select').name('Select an OPI');
+
+    // Coord
+    controllers.coord = viewer.menuGlobe.gui.add(editing, 'coord').name('Coordinates');
+    controllers.coord.listen();
 
     // Saisie
     controllers.polygon = viewer.menuGlobe.gui.add(editing, 'polygon').name('Start polygon');
@@ -212,6 +209,11 @@ async function main() {
     controllers.redo = viewer.menuGlobe.gui.add(editing, 'redo');
     controllers.clear = viewer.menuGlobe.gui.add(editing, 'clear');
     controllers.hide(['polygon', 'undo', 'redo', 'clear']);
+
+    // Message
+    viewer.message = '';
+    controllers.message = viewer.menuGlobe.gui.add(viewer, 'message').name('Message');
+    controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
 
     // Couche d'alertes
     editing.alert = '';

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -110,6 +110,7 @@ async function main() {
       l <= overviews.dataSet.level.max; l += 1) {
       overviews.dataSet.limitsForGraph[l] = overviews.dataSet.limits[l];
     }
+    viewer.zoomMin = overviews.dataSet.level.max - nbSubLevelsPerCOG;
     // pour la fonction updateScaleWidget
     viewer.maxGraphDezoom = 2 ** nbSubLevelsPerCOG;
 

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -217,11 +217,18 @@ async function main() {
           controllers.checked.updateDisplay();
           viewer.comment = editing.featureSelectedGeom.properties.comment;
           controllers.comment.updateDisplay();
+          controllers.nbChecked.updateDisplay();
         });
+      getController(viewer.menuGlobe.gui, 'nbChecked').__li.style.display = '';
       getController(viewer.menuGlobe.gui, 'checked').__li.style.display = '';
       getController(viewer.menuGlobe.gui, 'comment').__li.style.display = '';
       viewer.refresh(branch.layers);
     });
+
+    editing.nbChecked = 'test';
+    controllers.nbChecked = viewer.menuGlobe.gui.add(editing, 'nbChecked');
+    getController(viewer.menuGlobe.gui, 'nbChecked').__li.style.display = 'none';
+    controllers.nbChecked.listen().domElement.parentElement.style.pointerEvents = 'none';
 
     editing.checked = false;
     controllers.checked = viewer.menuGlobe.gui.add(editing, 'checked');
@@ -285,6 +292,7 @@ async function main() {
       delete editing.alertLayerName;
       delete viewer.alertLayerName;
       controllers.alert.__select.options.selectedIndex = -1;
+      getController(viewer.menuGlobe.gui, 'nbChecked').__li.style.display = 'none';
       getController(viewer.menuGlobe.gui, 'checked').__li.style.display = 'none';
       getController(viewer.menuGlobe.gui, 'comment').__li.style.display = 'none';
     });
@@ -334,6 +342,7 @@ async function main() {
       delete editing.alertLayerName;
       delete viewer.alertLayerName;
       controllers.alert.__select.options.selectedIndex = -1;
+      getController(viewer.menuGlobe.gui, 'nbChecked').__li.style.display = 'none';
       getController(viewer.menuGlobe.gui, 'checked').__li.style.display = 'none';
       getController(viewer.menuGlobe.gui, 'comment').__li.style.display = 'none';
       controllers.branch = controllers.branch.options(branch.list.map((elem) => elem.name))
@@ -350,6 +359,7 @@ async function main() {
         delete editing.alertLayerName;
         delete viewer.alertLayerName;
         controllers.alert.__select.options.selectedIndex = -1;
+        getController(viewer.menuGlobe.gui, 'nbChecked').__li.style.display = 'none';
         getController(viewer.menuGlobe.gui, 'checked').__li.style.display = 'none';
         getController(viewer.menuGlobe.gui, 'comment').__li.style.display = 'none';
       });

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -279,8 +279,13 @@ async function main() {
 
     viewer.comment = '';
     controllers.comment = viewer.menuGlobe.gui.add(viewer, 'comment');
+    controllers.comment.onChange(() => {
+      console.log('edition du commentaire en cours');
+      editing.currentStatus = editing.STATUS.COMMENT;
+    });
     controllers.comment.onFinishChange(async (value) => {
-      console.log('change comment', value);
+      console.log('edition du commentaire terminée : ', value);
+      editing.currentStatus = editing.STATUS.RAS;
       if (value !== editing.featureSelectedGeom.properties.comment) {
         const idFeature = editing.featureSelectedGeom.properties.id;
         const res = await fetch(`${apiUrl}/alert/${idFeature}?comment=${value}`,

--- a/itowns/package-lock.json
+++ b/itowns/package-lock.json
@@ -98,29 +98,29 @@
       "dev": true
     },
     "@loaders.gl/las": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/las/-/las-3.0.12.tgz",
-      "integrity": "sha512-lX2ZforTUxvb3DiBlwJLENWJDPVT/PRj/q50tffbyr8GWIq86LOk/1B1hsFCw79f84fQGyzMxhcyM6HX02KxZw==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/las/-/las-3.0.13.tgz",
+      "integrity": "sha512-bM3J0OwL6ZcAKMGpmkhA+dtekuO7e/1JqwgTX0sMW8/8iR6365aQlC2W3GoKY137GT+zuceI4HilvHkt4+bSNA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.0.12",
-        "@loaders.gl/schema": "3.0.12"
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/schema": "3.0.13"
       }
     },
     "@loaders.gl/loader-utils": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.0.12.tgz",
-      "integrity": "sha512-J2cYU8d5mx/rDoKdl6SlvoyvO1PXNi6Upul1OGCDql7S/mq+M9afsvNmRraZJOzcoO5NuWq30Eoh3rWD2w5Mew==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.0.13.tgz",
+      "integrity": "sha512-tVDmytWaO1XHBV9F5UEQd55vAdnVDZhK2nUKY5oBfDlo1mG5PhXWOj2Za+yV4btMC86PWXYhLiUUgy+9vABPOw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.0.12",
+        "@loaders.gl/worker-utils": "3.0.13",
         "@probe.gl/stats": "^3.4.0"
       }
     },
     "@loaders.gl/schema": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.0.12.tgz",
-      "integrity": "sha512-xJOi6s8SxPwuRfSyiSeUfuXHP5uRBsZOQfBvZTuU8XUyUn3d/nvk5VOZQgo44XTMmY3CqhfMUOFP3etC5oczsA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.0.13.tgz",
+      "integrity": "sha512-w6jPTnaSE/d5EfIKSVNRGFxUb56EiJrbKBUbZ6OgRkBlDlmSbLvRoaH/Jz5TT8ewK7DF6pumMqTXJ/0n0SZ5Pw==",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "apache-arrow": "^4.0.0",
@@ -128,9 +128,9 @@
       }
     },
     "@loaders.gl/worker-utils": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.0.12.tgz",
-      "integrity": "sha512-xbZiYxGNLniXrCMNyvyw91I+DCOrclHc3mwtCPZaJQi+eEFaq0Kh7Lv9yUCE6cCgDLNJfjcfmbcyCBgwlvq7WA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.0.13.tgz",
+      "integrity": "sha512-QB4jZumKGsouJprPzNKnKXTXMLf89afBwmi4Rnnw4SVj49olPiAGh4FZjf00GHFHKZlvAj8LB5rfqwd+Te6IVA==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -556,9 +556,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
-          "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
+          "version": "14.17.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.34.tgz",
+          "integrity": "sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg=="
         }
       }
     },
@@ -3315,9 +3315,9 @@
       "dev": true
     },
     "itowns": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/itowns/-/itowns-2.36.0.tgz",
-      "integrity": "sha512-ZI/Lck5w7RJG1eyNxUuW8GV2rBiSbwgZUzCswyGbYjeSf5g2W/7zWAymyGLpv3J2SIzYRx8Yqc0rmofckz5d/g==",
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/itowns/-/itowns-2.36.1.tgz",
+      "integrity": "sha512-/yK+p9eA0x/H0EWw+nFuLLhNDrIC1UEgiv6/yeB1IrD66ymmNz3CjpwRwJpF+YYk+I5bsoZlULQThYr3aSVx/Q==",
       "requires": {
         "@loaders.gl/las": "^3.0.12",
         "@mapbox/mapbox-gl-style-spec": "^13.22.0",

--- a/itowns/package-lock.json
+++ b/itowns/package-lock.json
@@ -3315,12 +3315,12 @@
       "dev": true
     },
     "itowns": {
-      "version": "2.35.0",
-      "resolved": "https://registry.npmjs.org/itowns/-/itowns-2.35.0.tgz",
-      "integrity": "sha512-mf1Ak1iB24uipSqutRU05fg50IiJnX8A2kRoHGA9qzJutkA4HefA+VhgcMPOlBPwBYsLrIpAU0/mqJHeL0k70Q==",
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/itowns/-/itowns-2.36.0.tgz",
+      "integrity": "sha512-ZI/Lck5w7RJG1eyNxUuW8GV2rBiSbwgZUzCswyGbYjeSf5g2W/7zWAymyGLpv3J2SIzYRx8Yqc0rmofckz5d/g==",
       "requires": {
-        "@loaders.gl/las": "^3.0.9",
-        "@mapbox/mapbox-gl-style-spec": "^13.21.0",
+        "@loaders.gl/las": "^3.0.12",
+        "@mapbox/mapbox-gl-style-spec": "^13.22.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@tmcw/togeojson": "^4.5.0",
         "@tweenjs/tween.js": "^18.6.4",
@@ -5515,9 +5515,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
-      "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA=="
+      "version": "0.133.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.133.1.tgz",
+      "integrity": "sha512-WydohO8ll949B0FTD6MGz59Yv2Lwj8hvObg/0Heh2r42S6+tQC1WByfCNRdmG4D7+odfGod+n8JPV1I2xrboWw=="
     },
     "thunky": {
       "version": "1.1.0",

--- a/itowns/package.json
+++ b/itowns/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "itowns": "^2.36.0",
+    "itowns": "^2.36.1",
     "proj4": "^2.7.5",
     "shpjs": "^4.0.2",
     "three": "0.133.1"

--- a/itowns/package.json
+++ b/itowns/package.json
@@ -13,10 +13,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "itowns": "^2.35.0",
+    "itowns": "^2.36.0",
     "proj4": "^2.7.5",
     "shpjs": "^4.0.2",
-    "three": "^0.129.0"
+    "three": "0.133.1"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/middlewares/vector.js
+++ b/middlewares/vector.js
@@ -132,9 +132,30 @@ async function deleteVector(req, _res, next) {
   next();
 }
 
+async function updateAlert(req, _res, next) {
+  debug('>>UPDATE alert');
+  if (req.error) {
+    next();
+    return;
+  }
+  const params = matchedData(req);
+  const { idFeature, status, comment } = params;
+
+  try {
+    const vector = await db.updateAlert(req.client, idFeature, status, comment);
+    req.result = { json: `vecteur '${vector.name}' détruit (sur la branche '${vector.branch_name}')`, code: 200 };
+  } catch (error) {
+    debug(error);
+    req.error = error;
+  }
+  debug('  next>>');
+  next();
+}
+
 module.exports = {
   getVectors,
   getVector,
   postVector,
   deleteVector,
+  updateAlert,
 };

--- a/routes/vector.js
+++ b/routes/vector.js
@@ -1,5 +1,7 @@
 const router = require('express').Router();
-const { param, query, body } = require('express-validator');
+const {
+  param, query, body, oneOf,
+} = require('express-validator');
 const GJV = require('geojson-validation');
 const cache = require('../middlewares/cache');
 const branch = require('../middlewares/branch');
@@ -117,6 +119,24 @@ router.delete('/vector',
     .withMessage(createErrMsg.invalidParameter('idVector')),
   validateParams,
   vector.deleteVector,
+  pgClient.close,
+  returnMsg);
+
+router.put('/alert/:idFeature',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  param('idFeature'),
+  // .exists().withMessage(createErrMsg.missingParameter('idBranch'))
+  // .custom((value, { req }) => req.result.json.includes(Number(value)))
+  // .withMessage(createErrMsg.invalidParameter('idBranch')),
+  oneOf([
+    query('status')
+      .exists().withMessage(createErrMsg.missingParameter('status')),
+    query('comment')
+      .exists().withMessage(createErrMsg.missingParameter('comment')),
+  ]),
+  validateParams,
+  vector.updateAlert,
   pgClient.close,
   returnMsg);
 

--- a/sql/packo.sql
+++ b/sql/packo.sql
@@ -388,6 +388,33 @@ ALTER TABLE public.features ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
 
 
 --
+-- Name: feature_ctrs; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.feature_ctrs (
+    id integer NOT NULL,
+    status boolean,
+    comment character varying,
+    id_feature integer NOT NULL
+);
+
+
+ALTER TABLE public.feature_ctrs OWNER TO postgres;
+
+--
+-- Name: feature_ctrs_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.feature_ctrs ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.feature_ctrs_id_seq
+    START WITH 0
+    INCREMENT BY 1
+    MINVALUE 0
+    NO MAXVALUE
+    CACHE 1
+);
+
+
 --
 -- Name: styles; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -529,7 +556,23 @@ ALTER TABLE ONLY public.features
     ADD CONSTRAINT features_pkey PRIMARY KEY (id);
 
 
-----
+--
+-- Name: feature_ctrs feature_ctrs_id_feature_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.feature_ctrs
+    ADD CONSTRAINT feature_ctrs_id_feature_key UNIQUE (id_feature);
+
+
+--
+-- Name: feature_ctrs feature_ctrs_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.feature_ctrs
+    ADD CONSTRAINT feature_ctrs_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: styles styles_name_key; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -650,6 +693,14 @@ ALTER TABLE ONLY public.layers
 
 ALTER TABLE ONLY public.features
     ADD CONSTRAINT features_id_layer_fkey FOREIGN KEY (id_layer) REFERENCES public.layers(id) ON DELETE CASCADE NOT VALID;
+
+
+--
+-- Name: feature_ctrs feature_ctrs_id_feature_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.feature_ctrs
+    ADD CONSTRAINT feature_ctrs_id_feature_fkey FOREIGN KEY (id_feature) REFERENCES public.features(id) ON DELETE CASCADE NOT VALID;
 
 
 --


### PR DESCRIPTION
Objectif:
- Pouvoir ajouter une couche d'alerte pour parcourir les entités une par une et changer leur état.

Modifications:
- mise à jour itowns 2.36.1 permettant la gestion des couches de vecteurs ponctuel
- ajout d'un menu déroulant "alert" permettant de sélectionner une couche de vecteur annexe ajoutée qui deviendra la couche d'alerte
- une fois cette couche sélectionnée, il y a centrage sur la première entité et le style de cette couche est modifié en lien avec la propriété 'status' de chaque entité
- on peut se déplacer d'entités en entités à l'aide des flèche droite et gauche (ainsi que haut, bas) et cliquer sur une entité pour en changer.
- une couche Layer est ajoutée permettant de surligner l'entité sélectionnée
- Des qu'une entité est sélectionnée, 2 nouveaux boutons sont ajoutés permettant de modifier les valeurs en base des attributs "comment" et "status"
- ajout en base d'une nouvelle table 'feature_ctr' permettant d'ajouter des attributs propres à une feature donnée (pour le moment "status" (boolean) et "comment" (var char)