### PR TITLE
fix(API): fix GeoTransform on cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ par défaut:
 
 La doc de l'API est publiée directement par le service et est disponible à l'adresse : http://[serveur]:[port]/doc
 
+Attention, l'API utilise une version de GDAL pour la lecture et la création des images du cache. Si une version de GDAL est déjà présente sur la machine, il peut y avoir des problèmes avec la variable d'environnement **PROJ_LIB** qui indique l'emplacement du dossier qui contient la définition des systèmes de coordonnées. Dans ce cas, l'API va signaler une erreur lors de l'application d'une retouche (erreur visible dans la console côté serveur et dans l'interface iTowns côté client). Si cela se produit, il faut supprimer la variable d'environnement **PROJ_LIB** avant de lancer l'API.
+Sous MacOS ou Linux, cela peut être fait avec la commande:
+```
+unset PROJ_LIB
+```
+Sous Windows:
+```
+SET PROJ_LIB=
+```
+
+
 ### Principe de fonctionnement
 
 Ce service propose: 

--- a/gdal_processing.js
+++ b/gdal_processing.js
@@ -104,7 +104,7 @@ function getDefaultEncoded(mime, blocSize) {
 }
 
 function processPatchAsync(patch, blocSize) {
-  return new Promise((res) => {
+  return new Promise((res, reject) => {
     // On patch le graph
     const { mask } = patch;
     // On a modifier le cache, donc il faut forcer le refresh
@@ -167,8 +167,13 @@ function processPatchAsync(patch, blocSize) {
       debug('... fin application des patch');
       debug('creation des images en memoire...');
       // on verifie que l orientation est bien interprété
-      graph.srs.autoIdentifyEPSG();
-
+      try {
+        graph.srs.autoIdentifyEPSG();
+      } catch (error) {
+        console.log('Erreur dans la gestion des SRS');
+        console.log('Il faut probablement supprimer la variable PROJ_LIB de votre environement');
+        reject(new Error('PROJ_LIB Error'));
+      }
       const graphMem = gdal.open('graph', 'w', 'MEM', graph.size.x, graph.size.y, 3);
       graphMem.geoTransform = graph.geoTransform;
       graphMem.srs = graph.srs;

--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -106,7 +106,9 @@ class Editing {
       if (res.status === 200) {
         this.viewer.refresh(this.branch.layers);
       } else {
-        this.viewer.message = "polygon: out of OPI's bounds";
+        res.json().then((json) => {
+          this.viewer.message = json.msg;
+        });
       }
     });
   }


### PR DESCRIPTION
# Motivation 

Depuis le commit 3b673edd459d3b87127150a6786288ff42fa7404 les COG modifiés dans le cache (pour l'ortho et le graph) n'ont ni géoref ni SRS.

# Principe

Il faut ajouter la copie du geoTransform et du srs.
Attention:

- il faut veiller à bien utiliser les API Async de gdal-async (**geoTransformAsync**, **srsAsync**)
- il peut y avoir des interférences avec une config locale de GDAL: en particulier la variable PROJ_LIB. Dans ce cas, le SRS peut être non reconnu et l'image obtenue s'affiche dans QGis en SRS inconnu. Si nécessaire, faire un "unset PROJ_LIB" avant de lancer l'API