### PR TITLE
Création de couches d'annotations

### DIFF
--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -34,13 +34,27 @@ class Controller {
     this[dropBoxName].domElement.children[0].innerHTML = innerHTML;
     // this.editing.alert = value;
     this[dropBoxName].updateDisplay();
+    this[list.length > 0 ? 'setVisible' : 'hide']([dropBoxName]);
   }
 
-  resetAlerts() {
+  // resetAlerts() {
+  //   delete this.editing.alertLayerName;
+  //   delete this.viewer.alertLayerName;
+  //   this.alert.__select.options.selectedIndex = -1;
+  //   this.hide(['nbChecked', 'checked', 'comment']);
+  // }
+
+  resetAlertsAndAnnotations() {
     delete this.editing.alertLayerName;
     delete this.viewer.alertLayerName;
     this.alert.__select.options.selectedIndex = -1;
-    this.hide(['nbChecked', 'checked', 'comment']);
+    // delete this.editing.annotationLayer;
+    this.editing.annotationLayer = {
+      name: '',
+      id: undefined,
+    };
+    this.annotation.__select.options.selectedIndex = -1;
+    this.hide(['nbChecked', 'checked', 'comment', 'addPoint']);
   }
 
   setVisible(controllerName) {

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -259,9 +259,9 @@ class Viewer {
           layer.config,
         );
 
-        if (layerName === 'Patch') {
-          layer.buildExtent = false;
-        }
+        // if (layerName === 'Patch') {
+        //   layer.buildExtent = false;
+        // }
 
         layer.colorLayer.visible = layerList[layerName].visible;
         if (layerName === 'Contour') {

--- a/routes/vector.js
+++ b/routes/vector.js
@@ -140,4 +140,39 @@ router.put('/alert/:idFeature',
   pgClient.close,
   returnMsg);
 
+router.put('/:idBranch/annotation',
+  pgClient.open,
+  branch.getBranches.bind({ column: 'id' }),
+  param('idBranch')
+    .custom((value, { req }) => req.result.json.includes(Number(value)))
+    .withMessage(createErrMsg.invalidParameter('idBranch')),
+  query('name')
+    .exists().withMessage(createErrMsg.missingParameter('name'))
+    .escape(),
+  query('crs')
+    .exists().withMessage(createErrMsg.missingParameter('crs')),
+  validateParams,
+  vector.addAnnotationLayer,
+  pgClient.close,
+  returnMsg);
+
+router.put('/:idAnnotationLayer/feature',
+  pgClient.open,
+  vector.getVectors.bind({ column: 'id' }),
+  param('idAnnotationLayer')
+    .exists().withMessage(createErrMsg.missingParameter('idAnnotationLayer'))
+    .custom((value, { req }) => req.result.json.includes(Number(value)))
+    .withMessage(createErrMsg.invalidParameter('idAnnotationLayer')),
+  query('x')
+    .exists().withMessage(createErrMsg.missingParameter('x'))
+    .escape(),
+  query('y')
+    .exists().withMessage(createErrMsg.missingParameter('y')),
+  query('comment')
+    .exists().withMessage(createErrMsg.missingParameter('comment')),
+  validateParams,
+  vector.addAnnotation,
+  pgClient.close,
+  returnMsg);
+
 module.exports = router;

--- a/sql/packo.sql
+++ b/sql/packo.sql
@@ -340,7 +340,8 @@ CREATE TABLE public.layers (
     num integer NOT NULL,
     crs character varying NOT NULL,
     id_branch integer NOT NULL,
-    id_style integer NOT NULL
+    id_style integer NOT NULL,
+    is_annotation boolean
 );
 
 


### PR DESCRIPTION
Se base sur la PR alerts2 #242 

Objectifs
- Permettre la création de couche vecteur d'annotation (création de couche + création de ponctuels avec commentaire)

Modifications:
- Ajout d'un bouton 'Add annotation layer' permettant la création d'une nouvelle couche vecteur
- Dès qu'il y a existence d'au moins une couche d'annotation, un menu déroulant contenant l'ensemble des couches apparait permettant de sélectionner une couche d'annotation pour la rendre active.
- Une fois une couche d'annotation 'active' un bouton 'Add annotation' apparait permettant d'enregistrer un nouveau ponctuel avec un commentaire

Modifications associées :
- (BdD) ajout d'une propriété "is_annotation" (booléen) dans la table "Layers"
- Disparition du menu déroulant 'Alerts Layer' si aucune couche d'alertes n'a été ajoutée.