### PR TITLE
Fix : Ajout couche d'alertes

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,10 @@ A partir du client web en ajoutant le paramètre namecache={nom du cache en base
 
 ### Import de couches vecteur annexes
 
-A partir de l'interface web, on peut intégrer des couches vecteur (au format geojson ou shapefile) en les glissant directement dans la vue.
-Celle-ci est ensuite sauvegardée dans la base de données.
+A partir de l'interface web, on peut intégrer des couches vecteur (au format geojson ou shapefile) en les glissant directement dans la vue. 
+Pour les fichiers shapefile, il faut glisser les fichiers .shp, .shx, .dbf et .prj en même temps.
+Pour des soucis d'intégrité, si on désire ajouter plusieurs couches, il faut les ajouter une à une.
+Chaque couche ajoutée est sauvegardée dans la base de données.
 
 Les paramètres d'affichage des couches ne sont pas persistants après un changement de branche de saisie ou de rafraîchissement de la page dans le navigateur.
 

--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -39,7 +39,7 @@ class Controller {
   resetAlerts() {
     delete this.editing.alertLayerName;
     delete this.viewer.alertLayerName;
-    this.alert.__select.options.selectedIndex = -1;
+    this.alert.__select.options.selectedIndex = 0;
     this.hide(['nbChecked', 'checked', 'comment']);
     if (this.viewer.view.getLayerById('selectedFeature')) {
       this.viewer.view.removeLayer('selectedFeature');

--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -41,6 +41,9 @@ class Controller {
     delete this.viewer.alertLayerName;
     this.alert.__select.options.selectedIndex = -1;
     this.hide(['nbChecked', 'checked', 'comment']);
+    if (this.viewer.view.getLayerById('selectedFeature')) {
+      this.viewer.view.removeLayer('selectedFeature');
+    }
   }
 
   setVisible(controllerName) {

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -120,11 +120,16 @@ async function main() {
       const folder = this[typeGui].addFolder(layer.id);
       folder.add({ visible: layer.visible }, 'visible').onChange(((value) => {
         layer.visible = value;
-        this.view.notifyChange(layer);
+
+        if (layer.id === editing.alertLayerName) {
+          viewer.view.getLayerById('selectedFeature').visible = value;
+        }
+
+        viewer.view.notifyChange(layer);
       }));
       folder.add({ opacity: layer.opacity }, 'opacity').min(0.001).max(1.0).onChange(((value) => {
         layer.opacity = value;
-        this.view.notifyChange(layer);
+        viewer.view.notifyChange(layer);
       }));
       // folder.add({ frozen: layer.frozen }, 'frozen').onChange(((value) => {
       //   layer.frozen = value;
@@ -133,14 +138,14 @@ async function main() {
       if (layer.effect_parameter) {
         folder.add({ thickness: layer.effect_parameter }, 'thickness').min(0.5).max(5.0).onChange(((value) => {
           layer.effect_parameter = value;
-          this.view.notifyChange(layer);
+          viewer.view.notifyChange(layer);
         }));
       }
       if (typeGui === 'vectorGui') {
         folder.add(branch, 'deleteVectorLayer').name('delete').onChange(() => {
           if (layer.id !== editing.alertLayerName) {
             branch.deleteVectorLayer(layer);
-            this.view.notifyChange(layer);
+            viewer.view.notifyChange(layer);
             controllers.refreshDropBox('alert', branch.vectorList
               .filter((elem) => elem.name !== layer.id)
               .map((elem) => elem.name));

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -335,10 +335,9 @@ async function main() {
 
     view.addEventListener('file-dropped', async (event) => {
       console.log('-> A file had been dropped');
+      // controllers.resetAlerts();
       await branch.saveLayer(event.name, event.data, event.style);
-      // view.getLayerById(event.name).vectorId = branch.layers[event.name].id;
       controllers.refreshDropBox('alert', branch.vectorList.map((elem) => elem.name));
-      controllers.resetAlerts();
     });
 
     view.addEventListener('branch-created', () => {

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -146,9 +146,9 @@ async function main() {
           if (layer.id !== editing.alertLayerName) {
             branch.deleteVectorLayer(layer);
             viewer.view.notifyChange(layer);
-            controllers.refreshDropBox('alert', branch.vectorList
+            controllers.refreshDropBox('alert', [' -', ...branch.vectorList
               .filter((elem) => elem.name !== layer.id)
-              .map((elem) => elem.name));
+              .map((elem) => elem.name)]);
           } else {
             viewer.message = 'Couche en edition';
           }
@@ -194,7 +194,7 @@ async function main() {
       };
       await branch.changeBranch();
       controllers.setEditingController();
-      controllers.refreshDropBox('alert', branch.vectorList.map((elem) => elem.name));
+      controllers.refreshDropBox('alert', [' -', ...branch.vectorList.map((elem) => elem.name)]);
       controllers.resetAlerts();
     });
     controllers.createBranch = viewer.menuGlobe.gui.add(branch, 'createBranch').name('Add new branch');
@@ -221,38 +221,42 @@ async function main() {
     controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
 
     // Couche d'alertes
-    editing.alert = '';
-    controllers.alert = viewer.menuGlobe.gui.add(editing, 'alert', branch.vectorList.map((elem) => elem.name)).name('Alerts Layer');
+    editing.alert = ' -';
+    controllers.alert = viewer.menuGlobe.gui.add(editing, 'alert', [' -', ...branch.vectorList.map((elem) => elem.name)]).name('Alerts Layer');
     controllers.alert.onChange(async (name) => {
       console.log('choosed alert vector layer: ', name);
 
-      editing.featureIndex = 0;
-      editing.alertLayerName = name;
-      viewer.alertLayerName = name;
+      if (name !== ' -') {
+        editing.featureIndex = 0;
+        editing.alertLayerName = name;
+        viewer.alertLayerName = name;
 
-      const layerTest = viewer.view.getLayerById(editing.alertLayerName);
-      editing.alertFC = await layerTest.source.loadData(undefined, layerTest);
-      editing.nbValidated = editing.alertFC.features[0].geometries.filter(
-        (elem) => elem.properties.status === true,
-      ).length;
-      editing.nbTotal = editing.alertFC.features[0].geometries.length;
-      editing.nbChecked = `${editing.nbValidated}/${editing.nbTotal}`;
+        const layerTest = viewer.view.getLayerById(editing.alertLayerName);
+        editing.alertFC = await layerTest.source.loadData(undefined, layerTest);
+        editing.nbValidated = editing.alertFC.features[0].geometries.filter(
+          (elem) => elem.properties.status === true,
+        ).length;
+        editing.nbTotal = editing.alertFC.features[0].geometries.length;
+        editing.nbChecked = `${editing.nbValidated}/${editing.nbTotal}`;
 
-      editing.centerOnAlertFeature();
-      // .then(() => {
-      //   editing.checked = editing.featureSelectedGeom.properties.status;
-      //   controllers.checked.updateDisplay();
-      //   viewer.comment = editing.featureSelectedGeom.properties.comment;
-      //   controllers.comment.updateDisplay();
-      //   controllers.nbChecked.updateDisplay();
-      // });
-      editing.checked = editing.featureSelectedGeom.properties.status;
-      controllers.checked.updateDisplay();
-      viewer.comment = editing.featureSelectedGeom.properties.comment;
-      controllers.comment.updateDisplay();
-      controllers.nbChecked.updateDisplay();
+        editing.centerOnAlertFeature();
+        // .then(() => {
+        //   editing.checked = editing.featureSelectedGeom.properties.status;
+        //   controllers.checked.updateDisplay();
+        //   viewer.comment = editing.featureSelectedGeom.properties.comment;
+        //   controllers.comment.updateDisplay();
+        //   controllers.nbChecked.updateDisplay();
+        // });
+        editing.checked = editing.featureSelectedGeom.properties.status;
+        controllers.checked.updateDisplay();
+        viewer.comment = editing.featureSelectedGeom.properties.comment;
+        controllers.comment.updateDisplay();
+        controllers.nbChecked.updateDisplay();
 
-      controllers.setVisible(['nbChecked', 'checked', 'comment']);
+        controllers.setVisible(['nbChecked', 'checked', 'comment']);
+      } else {
+        controllers.resetAlerts();
+      }
       viewer.refresh(branch.layers);
     });
     editing.nbChecked = 'test';
@@ -342,14 +346,13 @@ async function main() {
       console.log('-> A file had been dropped');
       // controllers.resetAlerts();
       await branch.saveLayer(event.name, event.data, event.style);
-      controllers.refreshDropBox('alert', branch.vectorList.map((elem) => elem.name));
+      controllers.refreshDropBox('alert', [' -', ...branch.vectorList.map((elem) => elem.name)]);
     });
 
     view.addEventListener('branch-created', () => {
       console.log('-> New branch created');
       controllers.setEditingController();
-      controllers.refreshDropBox('alert', branch.vectorList.map((elem) => elem.name));
-
+      controllers.refreshDropBox('alert', [' -', ...branch.vectorList.map((elem) => elem.name)]);
       controllers.resetAlerts();
       controllers.branch = controllers.branch.options(branch.list.map((elem) => elem.name))
         .setValue(branch.active.name);
@@ -361,7 +364,7 @@ async function main() {
         };
         await branch.changeBranch();
         controllers.setEditingController();
-        controllers.refreshDropBox('alert', branch.vectorList.map((elem) => elem.name));
+        controllers.refreshDropBox('alert', [' -', ...branch.vectorList.map((elem) => elem.name)]);
         controllers.resetAlerts();
       });
     });

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -296,6 +296,7 @@ async function main() {
           });
         if (res.status === 200) {
           viewer.refresh(branch.layers);
+          editing.alertFC.features[0].geometries[editing.featureIndex].properties.comment = value;
         } else {
           viewer.message = 'PB with validate';
         }

--- a/itowns/webpack.config.js
+++ b/itowns/webpack.config.js
@@ -6,12 +6,17 @@ module.exports = {
   entry: './index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
+    publicPath: '/dist',
     filename: 'bundle.js',
   },
   mode,
   devServer: {
     port: 8000,
-    publicPath: '/dist',
+    // publicPath: '/dist',
+    static: path.resolve(__dirname, './'),
+    devMiddleware: {
+      publicPath: '/dist',
+    },
   },
 };
 


### PR DESCRIPTION
Corrections de bugs en lien avec la PR permettant l'ajout de couche vecteur.

Fix : 
- bug lors de l'ajout d'une couche vecteur et rafraichissement de la couche d'alerte
   #258 
- bug lorsque l'on rend la couche d'alerte invisible et entité sélectionnée
  #262 (2eme point)
- nouvelle fonctionnalité : pouvoir désélectionner la couche d'alerte
  #262 (1er point)
- fix bug lors de la mise à jour du champ 'comment' qui n'était pas répertoriée sur la couche courante

Autre :
- Fix d'un bug en lien avec l'upgrade des package webpack