### PR TITLE
Gestion des couches en fonction du niveau de zoom

### DIFF
--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -299,25 +299,26 @@ class Editing {
       this.cancelcurrentPolygon();
     } else if (e.key === 'Shift') {
       if (this.currentStatus === status.POLYGON) {
-        if (this.currentPolygon && (this.nbVertices > 2)) {
-          if (this.branch.active.name !== 'orig') {
+        if (this.currentPolygon) {
+          if (this.branch.active.name === 'orig') {
+            this.viewer.message = 'Changer de branche pour continuer';
+          } else if (this.viewer.dezoom > this.viewer.maxGraphDezoom) {
+            this.viewer.message = 'Zoom non valide pour continuer';
+          } else if (this.nbVertices < 3) {
+            this.viewer.message = 'Pas assez de points';
+          } else {
             this.currentStatus = status.ENDING;
             this.viewer.message = 'Cliquer pour valider la saisie';
-          } else {
-            this.viewer.message = 'Changer de branche pour continuer';
+            this.view.controls.setCursor('default', 'progress');
+
+            const vertices = this.currentPolygon.geometry.attributes.position;
+            vertices.copyAt(this.nbVertices, vertices, 0);
+            vertices.needsUpdate = true;
+
+            this.currentPolygon.geometry.setDrawRange(0, this.nbVertices + 1);
+            this.currentPolygon.geometry.computeBoundingSphere();
+            this.view.notifyChange(this.currentPolygon);
           }
-
-          this.view.controls.setCursor('default', 'progress');
-
-          const vertices = this.currentPolygon.geometry.attributes.position;
-          vertices.copyAt(this.nbVertices, vertices, 0);
-          vertices.needsUpdate = true;
-
-          this.currentPolygon.geometry.setDrawRange(0, this.nbVertices + 1);
-          this.currentPolygon.geometry.computeBoundingSphere();
-          this.view.notifyChange(this.currentPolygon);
-        } else {
-          this.viewer.message = 'Pas assez de points';
         }
       }
     } else if (e.key === 'Backspace') {
@@ -417,7 +418,11 @@ class Editing {
         break;
       }
       case status.POLYGON: {
-        if (this.branch.active.name !== 'orig') {
+        if (this.branch.active.name === 'orig') {
+          this.viewer.message = 'Changer de branche pour continuer';
+        } else if (this.viewer.dezoom > this.viewer.maxGraphDezoom) {
+          this.viewer.message = 'Zoom non valide pour continuer';
+        } else {
           // Cas ou l'on est en train de saisir un polygon : on ajoute un point
           this.viewer.message = 'Maj pour terminer';
 
@@ -436,8 +441,6 @@ class Editing {
             vertices.needsUpdate = true;
           }
           this.nbVertices += 1;
-        } else {
-          this.viewer.message = 'Changer de branche pour continuer';
         }
         break;
       }

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -210,7 +210,8 @@ class Viewer {
             opacity,
             style,
             zoom: {
-              min: source.isVectorSource ? this.zoomMin : this.overviews.dataSet.level.min,
+              min: layerName === 'Patches' ? this.zoomMinPatch : this.overviews.dataSet.level.min,
+              // min: this.overviews.dataSet.level.min,
               max: this.overviews.dataSet.level.max,
             },
           });
@@ -251,7 +252,11 @@ class Viewer {
           //   layerList[layerName].style.point.color = coloringAlerts;
           // }
           layer.config.style = new itowns.Style(layerList[layerName].style);
-          layer.config.zoom = { min: this.zoomMin, max: this.overviews.dataSet.level.max };
+          layer.config.zoom = {
+            min: this.overviews.dataSet.level.min,
+            max: this.overviews.dataSet.level.max,
+          };
+          // pas besoin de definir le zoom min pour patches car il y en a jamais sur la couche orig
         }
         layer.config.opacity = layerList[layerName].opacity;
         layer.colorLayer = new itowns.ColorLayer(

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -25,6 +25,7 @@ function updateScaleWidget(view, resolution, maxGraphDezoom) {
   document.getElementById('spanZoomWidget').innerHTML = dezoom <= 1 ? `zoom: ${1 / dezoom}` : `zoom: 1/${dezoom}`;
   document.getElementById('spanScaleWidget').innerHTML = `${distance.toFixed(2)} ${unit}`;
   document.getElementById('spanGraphVisibWidget').classList.toggle('not_displayed', dezoom > maxGraphDezoom);
+  return dezoom;
 }
 
 // check if string is in "x,y" format with x and y positive floats
@@ -333,12 +334,12 @@ async function main() {
     const { view } = viewer;
     view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
       console.info('-> View initialized');
-      updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
+      viewer.dezoom = updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
     });
     view.addEventListener(itowns.PLANAR_CONTROL_EVENT.MOVED, () => {
       console.info('-> View moved');
       if (view.controls.state === -1) {
-        updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
+        viewer.dezoom = updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
       }
     });
 
@@ -442,7 +443,7 @@ async function main() {
         view.camera.camera3D.zoom *= 2;
         view.camera.camera3D.updateProjectionMatrix();
         view.notifyChange(view.camera.camera3D);
-        updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
+        viewer.dezoom = updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
       }
       return false;
     });
@@ -452,7 +453,7 @@ async function main() {
         view.camera.camera3D.zoom *= 0.5;
         view.camera.camera3D.updateProjectionMatrix();
         view.notifyChange(view.camera.camera3D);
-        updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
+        viewer.dezoom = updateScaleWidget(view, viewer.resolution, viewer.maxGraphDezoom);
       }
       return false;
     });

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -85,7 +85,7 @@ async function main() {
       l <= overviews.dataSet.level.max; l += 1) {
       overviews.dataSet.limitsForGraph[l] = overviews.dataSet.limits[l];
     }
-    viewer.zoomMin = overviews.dataSet.level.max - nbSubLevelsPerCOG;
+    viewer.zoomMinPatch = overviews.dataSet.level.max - nbSubLevelsPerCOG;
     // pour la fonction updateScaleWidget
     viewer.maxGraphDezoom = 2 ** nbSubLevelsPerCOG;
 


### PR DESCRIPTION
Se base sur la PR #260 

Objectifs :
- visualiser les couches vecteurs (sauf patchs) à tout les niveaux
   #233 (4eme point)
- ne pas permettre la saisie de polygone à petite échelle
   #233 (3eme point)