### PR TITLE
fix(monitor): vectorId and deleteLayer

### DIFF
--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -313,7 +313,7 @@ class Viewer {
           this.layerIndex[layerName] = Math.max(...Object.values(this.layerIndex)) + 1;
         }
       }
-      if (layerList[layerName].id) {
+      if (layerList[layerName].id !== undefined) {
         layer.colorLayer.vectorId = layerList[layerName].id;
       }
     });


### PR DESCRIPTION
Fix d'un bug apparaissant lors de la suppression d'un couche vecteur.
Ce bug apparait lorsque l'on essaye de supprimer la *toute* première couche vecteur ajoutée. (première couche ajoutée après avoir poussé le premier cache dans une base de données nouvellement créée).