### PR TITLE
export CVS opi name/color int 32

### DIFF
--- a/scripts/export_dico.py
+++ b/scripts/export_dico.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+Script d'export d'une table de correspondance entre les entiers 32bits du graphe de mosaiquage et les noms d'OPI
+"""
+import os
+import argparse
+import json
+
+
+def read_args():
+    """Gestion des arguments"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", required=True, help="input overview")
+    parser.add_argument(
+        "-o", "--output", required=True, help="output CSV file"
+    )
+    return  parser.parse_args()
+
+args = read_args()
+
+fileOverviews = open(args.input)
+overviews = json.load(fileOverviews)
+fileOverviews.close()
+
+with open(args.output, 'w') as out:
+    for opi in overviews['list_OPI']:
+        colors = overviews['list_OPI'][opi]
+        out.write(opi + ';' + str(colors[0] + 256 * (colors[1] + 256 * colors[2])) + '\n')
+


### PR DESCRIPTION
# Motivation
Pour pouvoir trouver les bons attributs après l'export vecteur, il est pratique de pouvoir exporter sous forme d'un CVS l'association entre les noms d'OPI et la couleur sous forme d'un entier 32 bits (R + 256 * (V + 256 * B)).

# Principe
Proposition d'un script python "export_dico.py" pour créer le CSV à partir du fichier overviews.json d'un cache.

# Reste à faire
Relecture + mise à jour de la doc