### PR TITLE
Remarks: Modif route ajout/suppression de ponctuel

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -275,7 +275,8 @@ async function insertSlabs(pgClient, idPatch, slabs) {
 async function getLayers(pgClient, idBranch) {
   debug(`    ~~getLayers (idBranch: ${idBranch})`);
   const sql = format(
-    'SELECT layers.id, layers.name, num, crs, style_itowns, opacity, visibility FROM layers, styles WHERE layers.id_style=styles.id %s',
+    'SELECT layers.id, layers.name, num, crs, style_itowns, opacity, visibility '
+    + 'FROM layers, styles WHERE layers.id_style=styles.id %s',
     idBranch !== undefined ? `AND id_Branch=${idBranch}` : '',
   );
   debug('      ', sql);
@@ -520,7 +521,7 @@ async function deleteFeature(pgClient, idFeature) {
   const sqlDeleteFeature = format(
     'DELETE FROM features '
       + 'WHERE id = %s '
-      + 'RETURNING id as id_feature',
+      + 'RETURNING id as id_feature, id_layer',
     idFeature,
   );
 

--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -521,16 +521,16 @@ paths:
         '200':
           description: OK
 
-  '/{idVector}/feature':
+  '/{idRemarksVector}/feature':
     put:
       tags:
         - vector
-      summary: "Ajout d'un ponctuel sur la couche {idVector}"
-      description: ""
+      summary: "Ajout d'un ponctuel sur une couche 'Remarques'"
+      description: "Ne permet d'ajouter un ponctuel que sur une couche 'Remarques'."
       parameters:
         - in: path
-          name: idVector
-          description: l'identifiant de la couche à modifier
+          name: idRemarksVector
+          description: l'identifiant de la couche 'Remarques' à modifier
           required: true
           schema:
             type: integer
@@ -559,12 +559,12 @@ paths:
     delete:
       tags:
         - vector
-      summary: "Suppression d'un ponctuel sur la couche {idVector}"
-      description: ""
+      summary: "Suppression d'un ponctuel sur une couche 'Remarques'"
+      description: "Ne permet de supprimer un ponctuel que sur une couche 'Remarques'."
       parameters:
         - in: path
-          name: idVector
-          description: l'identifiant de la couche à modifier
+          name: idRemarksVector
+          description: l'identifiant de la couche 'Remarques' à modifier
           required: true
           schema:
             type: integer

--- a/regress/4_vector.js
+++ b/regress/4_vector.js
@@ -262,23 +262,25 @@ describe('Vector', () => {
             res.should.have.status(400);
             const resJson = JSON.parse(res.text);
             resJson.should.be.an('array').to.have.lengthOf(1);
-            resJson[0].should.have.property('status').equal("Le paramètre 'idLayer' n'est pas valide.");
+            resJson[0].should.have.property('status').equal("Le paramètre 'idRemarksVector' n'est pas valide.");
             done();
           });
       });
     });
     describe('should return the id on the newly created feature', () => {
       it('should succeed', (done) => {
+        const x = 0;
+        const y = 0;
         chai.request(app)
           .put(`/${idRemarksVector}/feature`)
-          .query({ x: 0, y: 0, comment: 'test' })
+          .query({ x, y, comment: 'test' })
           .end((err, res) => {
             should.not.exist(err);
             res.should.have.status(200);
             const resJson = JSON.parse(res.text);
-            // Faire plus proprement
-            setIdFeature(resJson.split("'")[1]);
-            resJson.should.equal(`remarque '${idFeature}' ajoutée`);
+            resJson.should.have.property('idFeature');
+            setIdFeature(resJson.idFeature);
+            resJson.should.have.property('msg').equal(`un point a été ajouté aux coordonnées ${x},${y} sur la couche 'Remarques' (id : ${idRemarksVector})`);
             done();
           });
       });
@@ -342,7 +344,7 @@ describe('Vector', () => {
             res.should.have.status(400);
             const resJson = JSON.parse(res.text);
             resJson.should.be.an('array').to.have.lengthOf(1);
-            resJson[0].should.have.property('status').equal("Le paramètre 'idLayer' n'est pas valide.");
+            resJson[0].should.have.property('status').equal("Le paramètre 'idRemarksVector' n'est pas valide.");
             done();
           });
       });
@@ -356,7 +358,8 @@ describe('Vector', () => {
             should.not.exist(err);
             res.should.have.status(200);
             const resJson = JSON.parse(res.text);
-            resJson.should.equal(`remarque '${idFeature}' supprimée`);
+            resJson.should.have.property('idLayer');
+            resJson.should.have.property('msg').equal(`le point '${idFeature}' a été supprimé de la couche 'Remarques' (id : ${resJson.idLayer})`);
             done();
           });
       });

--- a/routes/vector.js
+++ b/routes/vector.js
@@ -158,13 +158,13 @@ router.put('/vector/:idFeature',
   pgClient.close,
   returnMsg);
 
-router.put('/:idLayer/feature',
+router.put('/:idRemarksVector/feature',
   pgClient.open,
-  vector.getVectors.bind({ column: 'id' }),
-  param('idLayer')
-    .exists().withMessage(createErrMsg.missingParameter('idLayer'))
+  vector.getVectors.bind({ column: 'id', selection: { column: 'name', value: 'Remarques' } }),
+  param('idRemarksVector')
+    .exists().withMessage(createErrMsg.missingParameter('idRemarksVector'))
     .custom((value, { req }) => req.result.getVectors.includes(Number(value)))
-    .withMessage(createErrMsg.invalidParameter('idLayer')),
+    .withMessage(createErrMsg.invalidParameter('idRemarksVector')),
   query('x')
     .exists().withMessage(createErrMsg.missingParameter('x')),
   query('y')
@@ -176,13 +176,13 @@ router.put('/:idLayer/feature',
   pgClient.close,
   returnMsg);
 
-router.delete('/:idLayer/feature',
+router.delete('/:idRemarksVector/feature',
   pgClient.open,
-  vector.getVectors.bind({ column: 'id' }),
-  param('idLayer')
-    .exists().withMessage(createErrMsg.missingParameter('idLayer'))
+  vector.getVectors.bind({ column: 'id', selection: { column: 'name', value: 'Remarques' } }),
+  param('idRemarksVector')
+    .exists().withMessage(createErrMsg.missingParameter('idRemarksVector'))
     .custom((value, { req }) => req.result.getVectors.includes(Number(value)))
-    .withMessage(createErrMsg.invalidParameter('idLayer')),
+    .withMessage(createErrMsg.invalidParameter('idRemarksVector')),
   query('id')
     .exists().withMessage(createErrMsg.missingParameter('id')),
   validateParams,


### PR DESCRIPTION
Objectif : 
Limiter l'ajout (et suppression) de ponctuel sur les couches 'Remarques'

Modification : 
- Ajout d'une contrainte sur l'identifiant du vecteur en entrée
- Modification du message de retour
- Mise a jour du swagger et des tests (pour vector.js)