### PR TITLE
fix(monitor): shortcut for redo

### DIFF
--- a/itowns/index.js
+++ b/itowns/index.js
@@ -593,6 +593,10 @@ async function main() {
       return false;
     });
 
+    // disable itowns shortcuts because of conflicts with endogenous shortcuts
+    /* eslint-disable-next-line no-underscore-dangle */
+    view.domElement.removeEventListener('keydown', view.controls._handlerOnKeyDown, false);
+
     const helpContent = document.getElementById('help-content');
     helpContent.style.visibility = 'hidden';
     document.getElementById('help').addEventListener('click', () => {


### PR DESCRIPTION
Remplacement du raccourci pour "redo" : "CTRL+Q" au lieu de "CTRL+Y", car "CTRL+Y" crée des conflits d'utilisation dans le navigateur avec pour effet le déplacement de la vue au dezoom par défaut 1/16