### PR TITLE
monitor : gestion des erreurs et retour utilisateur

### DIFF
--- a/itowns/Branch.js
+++ b/itowns/Branch.js
@@ -118,9 +118,24 @@ class Branch {
     console.log(branchName);
     if (branchName === null) return;
     if (branchName.length === 0) {
-      this.viewer.message = 'le nom n\'est pas valide';
+      const error = new Error('Ajout nouvelle branche -> le nom ne peut être vide');
+      error.name = 'Erreur ';
+      this.view.dispatchEvent({
+        type: 'error',
+        error,
+      });
       return;
     }
+    // pour l'issue #227
+    // if (!branchName[0].match(/[a-z0-9]/i)) {
+    //   const error = new Error('le nom doit commencer par une lettre ou un chiffre');
+    //   error.name = 'Erreur ';
+    //   this.view.dispatchEvent({
+    //     type: 'error',
+    //     error,
+    //   });
+    //   return;
+    // }
     this.addBranch(branchName);
   }
 

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -527,6 +527,12 @@ async function main() {
       }
     });
 
+    view.addEventListener('error', (ev) => {
+      // eslint-disable-next-line no-alert
+      console.log(ev.error instanceof Array ? ev.error.map((error) => error.message).join('') : ev.error.message);
+      window.alert(ev.error instanceof Array ? ev.error.join('') : ev.error);
+    });
+
     viewerDiv.addEventListener('mousemove', (ev) => {
       ev.preventDefault();
       editing.mousemove(ev);


### PR DESCRIPTION
Gestion des erreurs dans le monitor

Ajout d'un nouvel 'event' 'error' qui pourras être émis lorsque le code retourne une erreur et ainsi faire un retour utilisateur.

(Actuellement émis lors d'un nouveau nom de branche vide ou lors d'un drag and drop contenant des fichiers non supportés ou lors d'un drag and drop d'un fichier déjà ajouté)