### PR TITLE
fix(monitor): hide controllers when changing alert layer to an empty layer

### DIFF
--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -37,10 +37,10 @@ class Controller {
     this[dropBoxName].updateDisplay();
   }
 
-  resetAlerts() {
+  resetAlerts(keepName = false) {
     delete this.editing.alertLayerName;
     delete this.viewer.alertLayerName;
-    this.alert.__select.options.selectedIndex = 0;
+    if (!keepName) this.alert.__select.options.selectedIndex = 0;
     this.hide(['progress', 'id', 'validated', 'unchecked', 'comment', 'delRemark']);
     if (this.viewer.view.getLayerById('selectedFeature')) {
       this.viewer.view.removeLayer('selectedFeature');

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -279,6 +279,8 @@ async function main() {
     controllers.alert = viewer.menuGlobe.gui.add(editing, 'alert', [' -', ...branch.vectorList.map((elem) => elem.name)]).name('Alerts Layer');
     controllers.alert.onChange(async (name) => {
       console.log('choosed alert vector layer: ', name);
+      const keepName = true;
+      controllers.resetAlerts(keepName);
 
       if (name !== ' -') {
         editing.alertLayerName = name;
@@ -327,8 +329,6 @@ async function main() {
             controllers.hide(['delRemark']);
           }
         }
-      } else {
-        controllers.resetAlerts();
       }
       viewer.message = '';
       viewer.refresh(branch.layers);


### PR DESCRIPTION
Correction d'un bug lors du changement de couche d'alerte d'une couche non vide a une couche vide.
Issue #299 