### PR TITLE
Nouvel event pour le changement de branche et nettoyage Controller

### DIFF
--- a/itowns/Branch.js
+++ b/itowns/Branch.js
@@ -112,8 +112,11 @@ class Branch {
     });
   }
 
-  async changeBranch() {
-    console.log('changeBranch -> name:', this.active.name, 'id:', this.active.id);
+  async changeBranch(name) {
+    this.active = {
+      name,
+      id: this.list.filter((elem) => elem.name === name)[0].id,
+    };
     this.viewer.message = '';
     const listColorLayer = this.viewer.view.getLayers((l) => l.isColorLayer).map((l) => l.id);
     listColorLayer.forEach((element) => {
@@ -122,7 +125,10 @@ class Branch {
     });
     await this.setLayers();
     this.viewer.removeExtraLayers(this.viewer.menuGlobe);
-    this.viewer.refresh(this.layers);
+    this.view.dispatchEvent({
+      type: 'branch-changed',
+      name: this.active.name,
+    });
   }
 
   createBranch() {
@@ -161,9 +167,10 @@ class Branch {
       this.list = branches;
       this.active.name = branchName;
       this.active.id = this.list.filter((branch) => branch.name === branchName)[0].id;
-      await this.changeBranch();
       this.view.dispatchEvent({
         type: 'branch-created',
+        name: branchName,
+        id: this.active.id,
       });
     } else {
       res.text().then((err) => {

--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -20,31 +20,6 @@ class Controller {
     return controller;
   }
 
-  setEditingController() {
-    const brancheName = this.editing.branch.active.name;
-    this[brancheName !== 'orig' ? 'setVisible' : 'hide'](['polygon', 'undo', 'redo']);
-    if (process.env.NODE_ENV === 'development') this[brancheName !== 'orig' ? 'setVisible' : 'hide']('clear');
-  }
-
-  refreshDropBox(dropBoxName, list) {
-    let innerHTML = '';
-    list.forEach((element) => {
-      innerHTML += `<option value='${element}'>${element}</option>`;
-    });
-    this[dropBoxName].domElement.children[0].innerHTML = innerHTML;
-    // this.editing.alert = value;
-    this[dropBoxName].updateDisplay();
-  }
-
-  resetAlerts(keepName = false) {
-    this.editing.alertLayerName = '-';
-    if (!keepName) this.alert.__select.options.selectedIndex = 0;
-    this.hide(['progress', 'id', 'validated', 'unchecked', 'comment', 'delRemark']);
-    if (this.editing.viewer.view.getLayerById('selectedFeature')) {
-      this.editing.viewer.view.removeLayer('selectedFeature');
-    }
-  }
-
   setVisible(controllerName) {
     const controllers = (typeof controllerName === 'string' || controllerName instanceof String) ? [controllerName] : controllerName;
     controllers.forEach((controller) => {
@@ -58,5 +33,38 @@ class Controller {
       this.getController(controller).__li.style.display = 'none';
     });
   }
+
+  setPatchCtr(branchName) {
+    this[branchName !== 'orig' ? 'setVisible' : 'hide'](['polygon', 'undo', 'redo']);
+    if (process.env.NODE_ENV === 'development') this[branchName !== 'orig' ? 'setVisible' : 'hide']('clear');
+  }
+
+  setAlertCtr(layerName) {
+    this[layerName !== '-' ? 'setVisible' : 'hide'](['progress', 'id', 'validated', 'unchecked', 'comment']);
+    this[layerName === 'Remarques' ? 'setVisible' : 'hide'](['delRemark']);
+  }
+
+  refreshDropBox(dropBoxName, listOfValues, valueToSelect = this[dropBoxName].getValue()) {
+    // by default (valueToSelect = undefined) the value before the refresh is kept
+    let selectedIndex = 0;
+    let innerHTML = '';
+    listOfValues.forEach((element, i) => {
+      innerHTML += `<option value='${element}'>${element}</option>`;
+      if (element === valueToSelect) {
+        selectedIndex = i;
+      }
+    });
+    this[dropBoxName].domElement.children[0].innerHTML = innerHTML;
+    this[dropBoxName].__select.options.selectedIndex = selectedIndex;
+  }
+
+  resetAlerts() {
+    this.editing.alertLayerName = '-';
+
+    if (this.editing.viewer.view.getLayerById('selectedFeature')) {
+      this.editing.viewer.view.removeLayer('selectedFeature');
+    }
+  }
 }
+
 export default Controller;

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -244,17 +244,10 @@ async function main() {
     // Gestion branche
     branch.branch = branch.active.name;
     controllers.branch = viewer.menuGlobe.gui.add(branch, 'branch', branch.list.map((elem) => elem.name)).name('Active branch');
-    controllers.branch.onChange(async (name) => {
+    controllers.branch.onChange((name) => {
       document.activeElement.blur();
       console.log('choosed branch: ', name);
-      branch.active = {
-        name,
-        id: branch.list.filter((elem) => elem.name === name)[0].id,
-      };
-      await branch.changeBranch();
-      controllers.setEditingController();
-      controllers.refreshDropBox('alert', ['-', ...branch.vectorList.map((elem) => elem.name)]);
-      controllers.resetAlerts();
+      branch.changeBranch(name);
     });
     controllers.createBranch = viewer.menuGlobe.gui.add(branch, 'createBranch').name('Add new branch');
 
@@ -450,24 +443,23 @@ async function main() {
       controllers.refreshDropBox('alert', ['-', ...branch.vectorList.map((elem) => elem.name)]);
     });
 
-    view.addEventListener('branch-created', () => {
-      console.log('-> New branch created');
-      controllers.setEditingController();
-      controllers.refreshDropBox('alert', ['-', ...branch.vectorList.map((elem) => elem.name)]);
-      controllers.resetAlerts();
+    view.addEventListener('branch-created', (newBranch) => {
+      console.log(`-> New branch created (name: '${newBranch.name}', id: ${newBranch.id})`);
+      branch.changeBranch(newBranch.name);
       controllers.branch = controllers.branch.options(branch.list.map((elem) => elem.name))
         .setValue(branch.active.name);
-      controllers.branch.onChange(async (name) => {
+      controllers.branch.onChange((name) => {
         console.log('choosed branch: ', name);
-        branch.active = {
-          name,
-          id: branch.list.filter((elem) => elem.name === name)[0].id,
-        };
-        await branch.changeBranch();
-        controllers.setEditingController();
-        controllers.refreshDropBox('alert', ['-', ...branch.vectorList.map((elem) => elem.name)]);
-        controllers.resetAlerts();
+        branch.changeBranch(name);
       });
+    });
+
+    view.addEventListener('branch-changed', (newBranch) => {
+      console.log(`branche changed to '${newBranch.name}'`);
+      controllers.setEditingController(newBranch.name);
+      controllers.refreshDropBox('alert', ['-', ...branch.vectorList.map((elem) => elem.name)]);
+      controllers.resetAlerts();
+      viewer.refresh(branch.layers, true);
     });
 
     view.addEventListener('remark-added', async () => {


### PR DESCRIPTION
Ajout d'un nouvel 'event' appelé lors d'un changement de branche. 
L'event création de branche ne fait ainsi plus que la création de branche.

Cela permet de faire du nettoyage sur le controller : 
- refreshDropBox : ajout d'un attribut pour conserver ou non la valeur initiale
