### PR TITLE
Ajout de la date et heure d'acquisition de l'Opi sélectionnée

### DIFF
--- a/itowns/Branch.js
+++ b/itowns/Branch.js
@@ -118,17 +118,12 @@ class Branch {
       name,
       id: this.list.filter((elem) => elem.name === name)[0].id,
     };
-    this.viewer.message = '';
-    const listColorLayer = this.viewer.view.getLayers((l) => l.isColorLayer).map((l) => l.id);
-    listColorLayer.forEach((element) => {
-      const regex = new RegExp(`^${this.apiUrl}\\/[0-9]+\\/`);
-      this.view.getLayerById(element).source.url = this.view.getLayerById(element).source.url.replace(regex, `${this.apiUrl}/${this.active.id}/`);
-    });
+    // this.viewer.message = '';
     await this.setLayers();
-    this.viewer.removeExtraLayers(this.viewer.menuGlobe);
     this.view.dispatchEvent({
       type: 'branch-changed',
       name: this.active.name,
+      id: this.active.id,
     });
   }
 

--- a/itowns/Branch.js
+++ b/itowns/Branch.js
@@ -95,7 +95,9 @@ class Branch {
       this.vectorList = await getVectorList;
     }
 
+    let layerIndex = this.layers.length;
     this.vectorList.forEach((vector) => {
+      layerIndex += 1;
       this.layers.push({
         name: vector.name,
         type: 'vector',
@@ -106,6 +108,7 @@ class Branch {
         style: JSON.parse(vector.style_itowns),
         vectorId: vector.id,
         isAlert: false,
+        layerIndex,
       });
     });
   }

--- a/itowns/Controller.js
+++ b/itowns/Controller.js
@@ -44,6 +44,10 @@ class Controller {
     this[layerName === 'Remarques' ? 'setVisible' : 'hide'](['delRemark']);
   }
 
+  setOpiCtr(opiName) {
+    this[opiName === 'none' ? 'hide' : 'setVisible'](['opiName', 'opiDate', 'opiTime']);
+  }
+
   refreshDropBox(dropBoxName, listOfValues, valueToSelect = this[dropBoxName].getValue()) {
     // by default (valueToSelect = undefined) the value before the refresh is kept
     let selectedIndex = 0;

--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -253,9 +253,9 @@ class Editing {
 
     // this.id = this.featureSelectedGeom.properties.id;
     this.id = this.featureIndex;
-    this.controllers.id.updateDisplay();
+    // this.controllers.id.updateDisplay();
     this.validated = this.featureSelectedGeom.properties.status;
-    this.controllers.validated.updateDisplay();
+    // this.controllers.validated.updateDisplay();
     // this.viewer.remark = this.featureSelectedGeom.properties.comment;
     this.comment = this.featureSelectedGeom.properties.comment;
 
@@ -479,12 +479,12 @@ class Editing {
             this.cancelcurrentPolygon();
             if (res.status === 200) {
               this.opiName = json.opiName;
+              this.opiDate = json.date;
+              this.opiTime = json.time;
               this.color = json.color;
               this.controllers.opiName.__li.style.backgroundColor = `rgb(${this.color[0]},${this.color[1]},${this.color[2]})`;
               // On modifie la couche OPI
-              this.view.getLayerById('Opi').source.url = this.view.getLayerById('Opi').source.url.replace(/LAYER=.*&FORMAT/, `LAYER=opi&Name=${this.opiName}&FORMAT`);
-              this.view.getLayerById('Opi').visible = true;
-              this.viewer.refresh(this.branch.layers);
+              this.view.changeOpi(this.opiName);
             } else {
               console.log(`-> No OPI found (${json.msg})`);
               // 244-> no OPI at x, y (out of graph OR out of bounds)

--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -345,8 +345,10 @@ class Editing {
       if (this.opiName !== 'none' && (e.key === 'Escape')) {
         this.opiName = 'none';
         this.controllers.opiName.__li.style.backgroundColor = '';
-        this.view.getLayerById('Opi').visible = false;
-        this.view.notifyChange(this.view.getLayerById('Opi'), true);
+        this.view.dispatchEvent({
+          type: 'opi-selected',
+          name: 'none',
+        });
       } else if (this.alertLayerName !== '-' && this.alertFC.features.length > 0) {
         const { geometries } = this.alertFC.features[0];
         if (e.key === 'ArrowLeft') {

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -385,13 +385,15 @@ class Viewer {
       if (Object.keys(extensionsMap).includes(extension)) ListFile[layerName].nbFileDropped += 1;
     }
 
-    let data = {};
     // Read each file
+    const data = {};
     for (let i = 0; i < files.length; i += 1) {
       const file = files[i];
       let fileMtd = extensionsMap[file.name.split('.').pop().toLowerCase()];
       let layerName = file.name.split('.').slice(0, -1).join('.');
       layerName = layerName.charAt(0).toUpperCase() + layerName.slice(1);
+
+      if (!data[layerName]) data[layerName] = {};
 
       if (!fileMtd) {
         if (!errors[layerName]) {
@@ -420,18 +422,18 @@ class Viewer {
         let resData;
         nbFileLoaded += 1;
         if (fileMtd.format === _GEOJSON) {
-          data = JSON.parse(dataLoaded);
-          if (!data.type || data.type !== 'FeatureCollection' || !data.features) {
+          data[layerName] = JSON.parse(dataLoaded);
+          if (!data[layerName].type || data[layerName].type !== 'FeatureCollection' || !data[layerName].features) {
             if (!errors[layerName]) {
               errors[layerName] = ['File is not a valid geoJson'];
             } else {
               errors[layerName].push('File is not a valid geoJson');
             }
           } else {
-            resData = data;
+            resData = data[layerName];
           }
         } else if (fileMtd.format === _SHP) {
-          data[fileMtd.extension] = dataLoaded;
+          data[layerName][fileMtd.extension] = dataLoaded;
           ListFile[layerName].nbFileLoaded += 1;
           if (ListFile[layerName].nbFileLoaded < 4) {
             if (ListFile[layerName].nbFileLoaded === ListFile[layerName].nbFileDropped) {
@@ -444,8 +446,8 @@ class Viewer {
             }
           } else {
             resData = shp.combine([
-              shp.parseShp(data.shp, data.prj),
-              shp.parseDbf(data.dbf),
+              shp.parseShp(data[layerName].shp, data[layerName].prj),
+              shp.parseDbf(data[layerName].dbf),
             ]);
             resData.crs = { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::4326' } };
           }

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -192,13 +192,18 @@ class Viewer {
       viewer.refresh(layerList);
     };
 
+    const _view = this.view;
     this.view.changeOpi = function _(name) {
       console.log('Change Opi to', name);
       const regex = /LAYER=.*&FORMAT/;
       const layer = viewer.view.getLayerById('Opi');
       layer.source.url = layer.source.url.replace(regex, `LAYER=opi&Name=${name}&FORMAT`);
       layer.visible = true;
-      viewer.refresh('Opi');
+
+      _view.dispatchEvent({
+        type: 'opi-selected',
+        name,
+      });
     };
 
     this.view.changeBranch = function _(branchId) {

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -191,6 +191,24 @@ class Viewer {
       });
       viewer.refresh(layerList);
     };
+
+    this.view.changeOpi = function _(name) {
+      console.log('Change Opi to', name);
+      const regex = /LAYER=.*&FORMAT/;
+      const layer = viewer.view.getLayerById('Opi');
+      layer.source.url = layer.source.url.replace(regex, `LAYER=opi&Name=${name}&FORMAT`);
+      layer.visible = true;
+      viewer.refresh('Opi');
+    };
+
+    this.view.changeBranch = function _(branchId) {
+      console.log('Change Branch to', branchId);
+      const regex = new RegExp('\\/[0-9]+\\/');
+      ['Ortho', 'Opi', 'Graph', 'Contour', 'Patches'].forEach((element) => {
+        const layer = viewer.view.getLayerById(element);
+        layer.source.url = layer.source.url.replace(regex, `/${branchId}/`);
+      });
+    };
   }
 
   centerCamera(coordX, coordY) {
@@ -217,7 +235,8 @@ class Viewer {
     });
   }
 
-  refresh(layerList) {
+  refresh(layers) {
+    const layerList = layers instanceof Array ? layers : [layers];
     const layerNames = [];
     layerList.forEach((layer) => {
       layerNames.push(typeof layer === 'string' ? layer : layer.name);

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -83,7 +83,6 @@ class Viewer {
       Graph: 0,
       Contour: 3,
       Patches: 4,
-      Remarques: 5,
     };
     this.oldStyle = {};
 
@@ -291,6 +290,10 @@ class Viewer {
           // pas besoin de definir le zoom min pour patches car il y en a jamais sur la couche orig
         }
         config.opacity = layer.opacity;
+
+        if (layer.layerIndex !== undefined) {
+          this.layerIndex[layerName] = layer.layerIndex;
+        }
       }
 
       // Dans les 2 cas

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -195,7 +195,7 @@ async function main() {
     controllers.undo = viewer.menuGlobe.gui.add(editing, 'undo').name('undo [CTRL+Z]');
     controllers.redo = viewer.menuGlobe.gui.add(editing, 'redo').name('redo [CTRL+Y]');
     controllers.clear = viewer.menuGlobe.gui.add(editing, 'clear');
-    controllers.hide(['polygon', 'undo', 'redo', 'clear']);
+    // controllers.hide(['polygon', 'undo', 'redo', 'clear']);
 
     // Message
     viewer.message = '';
@@ -279,15 +279,15 @@ async function main() {
         controllers.id.updateDisplay();
       }
     });
-    controllers.hide('id');
+    // controllers.hide('id');
 
     editing.progress = '';
     controllers.progress = viewer.menuGlobe.gui.add(editing, 'progress').name('Progress');
     controllers.progress.listen().domElement.parentElement.style.pointerEvents = 'none';
-    controllers.hide('progress');
+    // controllers.hide('progress');
 
     controllers.unchecked = viewer.menuGlobe.gui.add(editing, 'unchecked').name('Mark as unchecked');
-    controllers.hide('unchecked');
+    // controllers.hide('unchecked');
 
     editing.validated = false;
     controllers.validated = viewer.menuGlobe.gui.add(editing, 'validated').name('Validated [c]');
@@ -317,17 +317,20 @@ async function main() {
         viewer.message = 'PB with validate';
       }
     });
-    controllers.hide('validated');
+    // controllers.hide('validated');
 
     editing.comment = '';
     controllers.comment = viewer.menuGlobe.gui.add(editing, 'comment').name('comment');
     controllers.comment.listen().domElement.parentElement.style.pointerEvents = 'none';
-    controllers.hide('comment');
+    // controllers.hide('comment');
 
     // Remarques
     controllers.addRemark = viewer.menuGlobe.gui.add(editing, 'addRemark').name('Add remark [a]');
     controllers.delRemark = viewer.menuGlobe.gui.add(editing, 'delRemark').name('Delete remark [d]');
-    controllers.hide('delRemark');
+    // controllers.hide('delRemark');
+
+    controllers.setPatchCtr('orig');
+    controllers.setAlertCtr('-');
 
     // editing controllers
     editing.controllers = {

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -396,7 +396,9 @@ async function main() {
       controllers.refreshDropBox('alert', ['-', ...branch.vectorList.map((elem) => elem.name)], '-');
       controllers.setAlertCtr('-');
       controllers.resetAlerts();
-      viewer.refresh(branch.layers, true);
+      viewer.removeExtraLayers(viewer.menuGlobe);
+      viewer.view.changeBranch(newBranch.id, apiUrl);
+      viewer.refresh(branch.layers);
     });
 
     view.addEventListener('remark-added', async () => {

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -399,7 +399,7 @@ async function main() {
     view.addEventListener('remark-added', async () => {
       console.log('-> A remark had been added');
       if (editing.alertLayerName === 'Remarques') {
-        const layerAlert = viewer.view.getLayerById(editing.alertLayerName);
+        const layerAlert = viewer.view.getLayerById('Remarques');
         await layerAlert.whenReady;
         editing.alertFC = await layerAlert.source.loadData(undefined, layerAlert);
 
@@ -412,13 +412,16 @@ async function main() {
         editing.nbTotal = editing.alertFC.features[0].geometries.length;
         editing.progress = `${editing.nbChecked}/${editing.nbTotal} (${editing.nbValidated} validés)`;
 
-        editing.centerOnAlertFeature();
+        if (editing.nbTotal === 1) {
+          editing.featureIndex = 0;
+          editing.centerOnAlertFeature();
+        }
         editing.validated = editing.featureSelectedGeom.properties.status;
         controllers.validated.updateDisplay();
         editing.comment = editing.featureSelectedGeom.properties.comment;
         // controllers.comment.updateDisplay();
 
-        controllers.setVisible(['progress', 'id', 'validated', 'unchecked', 'comment', 'delRemark']);
+        controllers.setAlertCtr('Remarques');
       }
     });
 
@@ -451,7 +454,7 @@ async function main() {
         editing.comment = editing.featureSelectedGeom.properties.comment;
         // controllers.comment.updateDisplay();
       } else {
-        controllers.hide(['progress', 'id', 'validated', 'unchecked', 'comment', 'delRemark']);
+        controllers.setAlertCtr('-');
         view.removeLayer('selectedFeature');
       }
     });

--- a/itowns/index.js
+++ b/itowns/index.js
@@ -182,13 +182,21 @@ async function main() {
     // Selection OPI
     controllers.select = viewer.menuGlobe.gui.add(editing, 'select').name('Select an OPI [s]');
     editing.opiName = 'none';
-    controllers.opiName = viewer.menuGlobe.gui.add(editing, 'opiName').name('OPI selected');
-    controllers.opiName.listen().domElement.parentElement.style.pointerEvents = 'none';
+    controllers.opiName = viewer.menuGlobe.gui.add(editing, 'opiName').name('OPI selected').listen();
+    controllers.opiName.domElement.parentElement.style.pointerEvents = 'none';
+    controllers.opiName.onChange((name) => {
+      console.log('opi selected: ', name);
+    });
+    editing.opiDate = '';
+    controllers.opiDate = viewer.menuGlobe.gui.add(editing, 'opiDate').name('Date').listen();
+    controllers.opiDate.domElement.parentElement.style.pointerEvents = 'none';
+    editing.opiTime = '';
+    controllers.opiTime = viewer.menuGlobe.gui.add(editing, 'opiTime').name('Time').listen();
+    controllers.opiTime.domElement.parentElement.style.pointerEvents = 'none';
 
     // Coord
     editing.coord = `${viewer.xcenter.toFixed(2)},${viewer.ycenter.toFixed(2)}`;
-    controllers.coord = viewer.menuGlobe.gui.add(editing, 'coord').name('Coordinates');
-    controllers.coord.listen();
+    controllers.coord = viewer.menuGlobe.gui.add(editing, 'coord').name('Coordinates').listen();
 
     // Saisie
     controllers.polygon = viewer.menuGlobe.gui.add(editing, 'polygon').name('Start polygon [p]');
@@ -199,8 +207,8 @@ async function main() {
 
     // Message
     viewer.message = '';
-    controllers.message = viewer.menuGlobe.gui.add(viewer, 'message').name('Message');
-    controllers.message.listen().domElement.parentElement.style.pointerEvents = 'none';
+    controllers.message = viewer.menuGlobe.gui.add(viewer, 'message').name('Message').listen();
+    controllers.message.domElement.parentElement.style.pointerEvents = 'none';
 
     // Couche d'alertes
     editing.alert = '-';
@@ -245,11 +253,11 @@ async function main() {
           editing.featureIndex = featureIndex;
 
           editing.id = 0;
-          controllers.id.updateDisplay();
+          // controllers.id.updateDisplay();
 
           editing.centerOnAlertFeature();
           editing.validated = editing.featureSelectedGeom.properties.status;
-          controllers.validated.updateDisplay();
+          // controllers.validated.updateDisplay();
 
           editing.comment = editing.featureSelectedGeom.properties.comment;
           // controllers.comment.updateDisplay();
@@ -260,7 +268,7 @@ async function main() {
       controllers.setAlertCtr(editing.nbTotal === 0 ? '-' : layerName);
     });
     editing.id = '';
-    controllers.id = viewer.menuGlobe.gui.add(editing, 'id').name('Alert id');
+    controllers.id = viewer.menuGlobe.gui.add(editing, 'id').name('Alert id').listen();
     controllers.id.onChange(() => {
       console.log("saisie d'une id");
       editing.currentStatus = editing.STATUS.WRITING;
@@ -276,21 +284,21 @@ async function main() {
       } else {
         viewer.message = 'id non valide';
         editing.id = editing.featureIndex;
-        controllers.id.updateDisplay();
+        // controllers.id.updateDisplay();
       }
     });
     // controllers.hide('id');
 
     editing.progress = '';
-    controllers.progress = viewer.menuGlobe.gui.add(editing, 'progress').name('Progress');
-    controllers.progress.listen().domElement.parentElement.style.pointerEvents = 'none';
+    controllers.progress = viewer.menuGlobe.gui.add(editing, 'progress').name('Progress').listen();
+    controllers.progress.domElement.parentElement.style.pointerEvents = 'none';
     // controllers.hide('progress');
 
     controllers.unchecked = viewer.menuGlobe.gui.add(editing, 'unchecked').name('Mark as unchecked');
     // controllers.hide('unchecked');
 
     editing.validated = false;
-    controllers.validated = viewer.menuGlobe.gui.add(editing, 'validated').name('Validated [c]');
+    controllers.validated = viewer.menuGlobe.gui.add(editing, 'validated').name('Validated [c]').listen();
     controllers.validated.domElement.id = 'validatedAlert';
     controllers.validated.onChange(async (value) => {
       console.log('change status', value);
@@ -320,8 +328,8 @@ async function main() {
     // controllers.hide('validated');
 
     editing.comment = '';
-    controllers.comment = viewer.menuGlobe.gui.add(editing, 'comment').name('comment');
-    controllers.comment.listen().domElement.parentElement.style.pointerEvents = 'none';
+    controllers.comment = viewer.menuGlobe.gui.add(editing, 'comment').name('comment').listen();
+    controllers.comment.domElement.parentElement.style.pointerEvents = 'none';
     // controllers.hide('comment');
 
     // Remarques
@@ -329,8 +337,9 @@ async function main() {
     controllers.delRemark = viewer.menuGlobe.gui.add(editing, 'delRemark').name('Delete remark [d]');
     // controllers.hide('delRemark');
 
-    controllers.setPatchCtr('orig');
-    controllers.setAlertCtr('-');
+    controllers.setPatchCtr(branch.active.name);// branch.active.name = 'orig'
+    controllers.setAlertCtr(editing.alert);// editing.alert = '-'
+    controllers.setOpiCtr(editing.opiName);// editing.opiName = 'none'
 
     // editing controllers
     editing.controllers = {
@@ -338,8 +347,8 @@ async function main() {
       opiName: controllers.opiName,
       polygon: controllers.polygon,
       // checked: controllers.checked,
-      id: controllers.id,
-      validated: controllers.validated,
+      // id: controllers.id,
+      // validated: controllers.validated,
       // comment: controllers.comment,
       addRemark: controllers.addRemark,
     };
@@ -384,6 +393,17 @@ async function main() {
         });
     });
 
+    view.addEventListener('opi-selected', (newOpi) => {
+      console.log(`-> Opi '${newOpi.name}' selected.`);
+      if (newOpi.name === 'none') {
+        view.getLayerById('Opi').visible = false;
+        view.notifyChange(view.getLayerById('Opi'), true);
+      } else {
+        viewer.refresh('Opi');
+      }
+      controllers.setOpiCtr(newOpi.name);
+    });
+
     view.addEventListener('branch-created', (newBranch) => {
       console.log(`-> New branch created (name: '${newBranch.name}', id: ${newBranch.id})`);
       branch.changeBranch(newBranch.name);
@@ -422,7 +442,7 @@ async function main() {
           editing.centerOnAlertFeature();
         }
         editing.validated = editing.featureSelectedGeom.properties.status;
-        controllers.validated.updateDisplay();
+        // controllers.validated.updateDisplay();
         editing.comment = editing.featureSelectedGeom.properties.comment;
         // controllers.comment.updateDisplay();
 
@@ -455,7 +475,7 @@ async function main() {
           editing.centerOnAlertFeature();
         }
         editing.validated = editing.featureSelectedGeom.properties.status;
-        controllers.validated.updateDisplay();
+        // controllers.validated.updateDisplay();
         editing.comment = editing.featureSelectedGeom.properties.comment;
         // controllers.comment.updateDisplay();
       } else {
@@ -499,9 +519,9 @@ async function main() {
           }
 
           editing.id = editing.featureIndex;
-          controllers.id.updateDisplay();
+          // controllers.id.updateDisplay();
           editing.validated = features[layerTest.id][0].geometry.properties.status;
-          controllers.validated.updateDisplay();
+          // controllers.validated.updateDisplay();
           editing.comment = features[layerTest.id][0].geometry.properties.comment;
           // controllers.comment.updateDisplay();
 

--- a/sql/packo.sql
+++ b/sql/packo.sql
@@ -562,8 +562,8 @@ ALTER TABLE ONLY public.layers
 -- Name: layers layers_num_id_branch_key; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY public.layers
-    ADD CONSTRAINT layers_num_id_branch_key UNIQUE (num, id_branch);
+-- ALTER TABLE ONLY public.layers
+--     ADD CONSTRAINT layers_num_id_branch_key UNIQUE (num, id_branch);
 
 
 --


### PR DESCRIPTION
PR permettant l'affichage des données liée au Opi

Cette PR ajoute aussi quelques correctifs:
- Permettre l'ajout de plusieurs vecteurs annexe en une seule fois
- Fixer l'ordre des couches sur le Menu
- corriger le message d'erreur lorsque l'on ajoute une remarque sur une couche vierge

Autre modifications:
- suppressions des l'appels a hide() pour les controllers
- refactoring des modifications des source.url au niveau de view.