### PR TITLE
Fix icones pour boutons de zoom

### DIFF
--- a/itowns/css/Buttons.css
+++ b/itowns/css/Buttons.css
@@ -47,7 +47,6 @@
     background-color: #FFF;
     color: #505050;
     box-shadow: 0 0 5px #000;
-    background-size: 30px 150px;
     outline: none;
 }
 


### PR DESCRIPTION
Une modification du fichier geoportail a entrainé un décalage des imagette pour les boutons sur le monitor.

Cette PR vise a corriger ce problème.