### PR TITLE
Ajout LAMB93_20cm pour TILEMATRIXSET

### DIFF
--- a/doc/swagger.yml
+++ b/doc/swagger.yml
@@ -723,6 +723,7 @@ paths:
             type: string
             enum:
               - LAMB93_5cm
+              - LAMB93_20cm
             example: LAMB93_5cm
         - in: query
           name: TILEMATRIX


### PR DESCRIPTION
Dans swagger.yml, ajout LAMB93_20cm dans TILEMATRIXSET de la route GET /{idBranch}/wmts