### PR TITLE
fix(monitor): bug fix after deleting and creating the first alert

### DIFF
--- a/itowns/index.js
+++ b/itowns/index.js
@@ -360,7 +360,7 @@ async function main() {
         alert.progress = `${alert.nbChecked}/${alert.nbTotal} (${alert.nbValidated} validés)`;
 
         if (alert.nbTotal === 1) {
-          alert.changeFeature(0, { centerOnFeature: true });
+          alert.changeFeature(0, { centerOnFeature: true, forceRefresh: true });
           menu.setAlertCtr('Remarques');
         }
       }
@@ -386,6 +386,7 @@ async function main() {
 
         alert.selectPrevious({ centerOnFeature: true, forceRefresh: true });
       } else {
+        alert.nbTotal = 0;
         menu.setAlertCtr('-');
       }
     });


### PR DESCRIPTION
En lien avec l'issue #368 

Fix aussi les erreurs consoles en lien avec l'utilisation de 'd' quand il n'y a plus rien à supprimer.