### PR TITLE
Fix qview - latest qgis api ltr

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Si un cache a une taille de dalle (slabSize) différente de 16x16 tuiles ou une 
 
 ## Préparation des éléments de la vue PackO pour QGIS
 
-Dans le cas d'utilisation d'un client pour PackO basé sur QGIS, on peut créer automatiquement la vue contenant les éléments du chantier en utilisant le script **create_qgis_view.py** :
+Dans le cas d'utilisation d'un client pour PackO basé sur QGIS (version minimale 3.34), on peut créer automatiquement la vue contenant les éléments du chantier en utilisant le script **create_qgis_view.py** :
 ````
 usage: create_qgis_view.py [-h] [-u URL] -c CACHE_ID [-b BRANCH_NAME] [-s {RVB,IR,IRC}] [-o OUTPUT] [-z ZOOM_PIVOT] [--vect VECT] [--bbox BBOX BBOX BBOX BBOX] [-m MACROS] [-v VERBOSE]
 

--- a/scripts/process_qlayers.py
+++ b/scripts/process_qlayers.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """ This script handles QGIS layers """
 
-from qgis.core import QgsRasterLayer, QgsVectorLayer, QgsVectorFileWriter
+from qgis.core import QgsRasterLayer, QgsVectorLayer, QgsVectorFileWriter, QgsEditFormConfig
 
 
 def add_layer_to_map(data_source, layer_name, qgs_project, provider_name,
@@ -15,7 +15,7 @@ def add_layer_to_map(data_source, layer_name, qgs_project, provider_name,
     qgs_project.addMapLayer(layer, show)
     if disable_att_form_popup is True:
         form_config = layer.editFormConfig()
-        form_config.setSuppress(1)
+        form_config.setSuppress(QgsEditFormConfig.SuppressOn)
         layer.setEditFormConfig(form_config)
     return layer
 


### PR DESCRIPTION
La classe QGIS API utilisée pour désactiver le formulaire pop-up a changé de manière cassante dans la nouvelle ltr de l'api qgis 3.34.
J'ai fait le nécessaire pour le script de création de vue qgis et fixé la version minimale de QGIS à 3.34 dans la doc