### PR TITLE
Enhance qgis view & macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,19 +352,21 @@ Des vecteurs externes *.shp* et *.gpkg* peuvent être intégrés à la vue en in
 
 Dans le cas où l'on veut avoir une emprise pour la vue (emprise de travail) plus petite que l'emprise du chantier (emprise du cache), elle est à indiquer avec **--bbox** Xmin Ymin Xmax Ymax.
 
-Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin vers le fichier macros prototype avec **-m**. Ce fichier sera adapté au chantier avant d'être intégré à la vue, en remplaçant les clés `__IDBRANCH__`, `__URLSERVER__` et `__TILEMATRIXSET__` avec les valeurs correspondantes pour le chantier - exemple :
+Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin vers le fichier macros prototype avec **-m**. Ce fichier sera adapté au chantier avant d'être intégré à la vue, en remplaçant les clés `__IDBRANCH__`, `__URLSERVER__`, `__TILEMATRIXSET__`, `__STYLE__` avec les valeurs correspondantes pour le chantier - exemple :
 
   - Extrait prototype macros, avant adaptation :
     ```
     id_branch = __IDBRANCH__
     url_server = __URLSERVER__
     tile_matrix_set = __TILEMATRIXSET__
+    style = __STYLE__
     ```
   - Extrait macros, après adaptation :
     ```
     id_branch = '32'
     url_server = 'http://localhost:8081/'
     tile_matrix_set = 'LAMB93_20cm'
+    style = 'RVB'
     ```
 
 Un exemple de fichier macros prototype est fourni dans le dossier *ressources*.

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Des vecteurs externes *.shp* et *.gpkg* peuvent être intégrés à la vue en in
 
 Dans le cas où l'on veut avoir une emprise pour la vue (emprise de travail) plus petite que l'emprise du chantier (emprise du cache), elle est à indiquer avec **--bbox** Xmin Ymin Xmax Ymax.
 
-Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin vers le fichier macros prototype avec **-m**. Ce fichier sera adapté au chantier avant d'être intégré à la vue, en remplaçant les clés `__IDBRANCH__`, `__URLSERVER__`, `__TILEMATRIXSET__`, `__STYLE__`, `__PIXELSIZEX__`, `__PIXELSIZEY__`  avec les valeurs correspondantes pour le chantier - exemple :
+Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin vers le fichier macros prototype avec **-m**. Ce fichier sera adapté au chantier avant d'être intégré à la vue, en remplaçant les clés `__IDBRANCH__`, `__URLSERVER__`, `__TILEMATRIXSET__`, `__STYLE__`, `__CRS__`, `__PIXELSIZEX__`, `__PIXELSIZEY__`  avec les valeurs correspondantes pour le chantier - exemple :
 
   - Extrait prototype macros, avant adaptation :
     ```
@@ -360,6 +360,7 @@ Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin v
     url_server = __URLSERVER__
     tile_matrix_set = __TILEMATRIXSET__
     style = __STYLE__
+    crs = __CRS__
     pixel_size_x = __PIXELSIZEX__
     pixel_size_y = __PIXELSIZEY__
     ```
@@ -369,6 +370,7 @@ Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin v
     url_server = 'http://localhost:8081/'
     tile_matrix_set = 'LAMB93_20cm'
     style = 'RVB'
+    crs = '2154'
     pixel_size_x = 0.2
     pixel_size_y = 0.2
     ```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Des vecteurs externes *.shp* et *.gpkg* peuvent être intégrés à la vue en in
 
 Dans le cas où l'on veut avoir une emprise pour la vue (emprise de travail) plus petite que l'emprise du chantier (emprise du cache), elle est à indiquer avec **--bbox** Xmin Ymin Xmax Ymax.
 
-Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin vers le fichier macros prototype avec **-m**. Ce fichier sera adapté au chantier avant d'être intégré à la vue, en remplaçant les clés `__IDBRANCH__`, `__URLSERVER__`, `__TILEMATRIXSET__`, `__STYLE__` avec les valeurs correspondantes pour le chantier - exemple :
+Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin vers le fichier macros prototype avec **-m**. Ce fichier sera adapté au chantier avant d'être intégré à la vue, en remplaçant les clés `__IDBRANCH__`, `__URLSERVER__`, `__TILEMATRIXSET__`, `__STYLE__`, `__PIXELSIZEX__`, `__PIXELSIZEY__`  avec les valeurs correspondantes pour le chantier - exemple :
 
   - Extrait prototype macros, avant adaptation :
     ```
@@ -360,6 +360,8 @@ Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin v
     url_server = __URLSERVER__
     tile_matrix_set = __TILEMATRIXSET__
     style = __STYLE__
+    pixel_size_x = __PIXELSIZEX__
+    pixel_size_y = __PIXELSIZEY__
     ```
   - Extrait macros, après adaptation :
     ```
@@ -367,6 +369,8 @@ Pour intégrer un fichier de macros QGIS à la vue, il faut indiquer le chemin v
     url_server = 'http://localhost:8081/'
     tile_matrix_set = 'LAMB93_20cm'
     style = 'RVB'
+    pixel_size_x = 0.2
+    pixel_size_y = 0.2
     ```
 
 Un exemple de fichier macros prototype est fourni dans le dossier *ressources*.

--- a/ressources/example_macros_qgis.py
+++ b/ressources/example_macros_qgis.py
@@ -36,6 +36,8 @@ id_branch = __IDBRANCH__
 url_server = __URLSERVER__
 tile_matrix_set = __TILEMATRIXSET__
 style = __STYLE__
+pixel_size_x = __PIXELSIZEX__
+pixel_size_y = __PIXELSIZEY__
 # ===================================
 
 url_graph = url_server + id_branch + '/graph'
@@ -296,7 +298,7 @@ def on_key(event):
 
             chem_export_txt = os.path.join(rep_pont, nom_export.replace('.tif', '.txt'))
 
-            cmd = f'gdalwarp -tr 0.05 0.05 -tap -r near -co TFW=YES {ortho_layer.source()} {chem_export}\
+            cmd = f'gdalwarp -tr {pixel_size_x} {pixel_size_y} -tap -r near -co TFW=YES {ortho_layer.source()} {chem_export}\
                 -cutline {src_poly} -csql "select ret.geom from retouches_info as ret where ret.fid == {id_poly}"\
                 -crop_to_cutline -overwrite -dstnodata 0'
             os.popen(cmd).readlines()

--- a/ressources/example_macros_qgis.py
+++ b/ressources/example_macros_qgis.py
@@ -36,6 +36,7 @@ id_branch = __IDBRANCH__
 url_server = __URLSERVER__
 tile_matrix_set = __TILEMATRIXSET__
 style = __STYLE__
+crs = __CRS__
 pixel_size_x = __PIXELSIZEX__
 pixel_size_y = __PIXELSIZEY__
 # ===================================
@@ -45,7 +46,7 @@ url_patch = url_server + id_branch + '/patch'
 url_undo = url_server + id_branch + '/patch/undo'
 url_redo = url_server + id_branch + '/patch/redo'
 url_wmts = url_server + id_branch + '/wmts'
-source='contextualWMSLegend=0&crs=EPSG:2154&dpiMode=7&featureCount=10&format=image/png&layers=opi&styles='+style+'&tileDimensions=Name%3DXXX&tileMatrixSet='+tile_matrix_set+'&url='+url_wmts+'?SERVICE%3DWMTS%26REQUEST%3DGetCapabilities%26VERSION%3D1.0.0'
+source='contextualWMSLegend=0&crs=EPSG:'+crs+'&dpiMode=7&featureCount=10&format=image/png&layers=opi&styles='+style+'&tileDimensions=Name%3DXXX&tileMatrixSet='+tile_matrix_set+'&url='+url_wmts+'?SERVICE%3DWMTS%26REQUEST%3DGetCapabilities%26VERSION%3D1.0.0'
 OPI=None
 color=None
 opi_layer = None
@@ -84,7 +85,7 @@ def sendPatch(feature, OPI, color):
     exporter = QgsJsonExporter()
     patch = json.loads(exporter.exportFeatures([feature]))
     # print(patch)
-    patch['crs'] = {'type': 'name', 'properties': {'name': 'urn:ogc:def:crs:EPSG::2154'}}
+    patch['crs'] = {'type': 'name', 'properties': {'name': 'urn:ogc:def:crs:EPSG::'+crs}}
     patch['features'][0]['properties'] = {'color': color, 'opiName': OPI}
     res = requests.post(url_patch, json=patch)
     return res.text

--- a/ressources/example_macros_qgis.py
+++ b/ressources/example_macros_qgis.py
@@ -35,6 +35,7 @@ def closeProject():
 id_branch = __IDBRANCH__
 url_server = __URLSERVER__
 tile_matrix_set = __TILEMATRIXSET__
+style = __STYLE__
 # ===================================
 
 url_graph = url_server + id_branch + '/graph'
@@ -42,7 +43,7 @@ url_patch = url_server + id_branch + '/patch'
 url_undo = url_server + id_branch + '/patch/undo'
 url_redo = url_server + id_branch + '/patch/redo'
 url_wmts = url_server + id_branch + '/wmts'
-source='contextualWMSLegend=0&crs=EPSG:2154&dpiMode=7&featureCount=10&format=image/png&layers=opi&styles=RVB&tileDimensions=Name%3DXXX&tileMatrixSet='+tile_matrix_set+'&url='+url_wmts+'?SERVICE%3DWMTS%26REQUEST%3DGetCapabilities%26VERSION%3D1.0.0'
+source='contextualWMSLegend=0&crs=EPSG:2154&dpiMode=7&featureCount=10&format=image/png&layers=opi&styles='+style+'&tileDimensions=Name%3DXXX&tileMatrixSet='+tile_matrix_set+'&url='+url_wmts+'?SERVICE%3DWMTS%26REQUEST%3DGetCapabilities%26VERSION%3D1.0.0'
 OPI=None
 color=None
 opi_layer = None

--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -13,6 +13,8 @@ from osgeo import osr
 
 import cache_def as cache
 
+# enable gdal/ogr exceptions
+gdal.UseExceptions()
 
 cpu_dispo = multiprocessing.cpu_count()
 

--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -11,6 +11,9 @@ import numpy as np
 from numpy import base_repr
 from osgeo import gdal
 
+# enable gdal/ogr exceptions
+gdal.UseExceptions()
+
 COG_DRIVER = gdal.GetDriverByName('COG')
 
 

--- a/scripts/create_qgis_view.py
+++ b/scripts/create_qgis_view.py
@@ -96,6 +96,19 @@ def suppress_cachetag(xml_in, xml_out):
     print(f"File '{xml_out}' written")
 
 
+def set_nb_bands(xml_in, xml_out, nb_bands):
+    """ Set number of bands or channels in xml file """
+    if nb_bands is None or nb_bands < 0:
+        raise SystemExit(f'ERROR: Bad number of bands (={nb_bands})')
+    tree_xml = etree.parse(xml_in)
+    root_xml = tree_xml.getroot()
+    bands_count = root_xml.find('BandsCount')
+    if bands_count is None:
+        raise SystemExit(f"ERROR: 'BandsCount' tag not found in '{xml_in}'")
+    bands_count.text = str(nb_bands)
+    tree_xml.write(xml_out)
+
+
 def set_extent_xml(xml_in, xml_out, extent_xmin, extent_ymin, extent_xmax, extent_ymax):
     """ Set extent limits in an xml file """
     tree_xml = etree.parse(xml_in)
@@ -117,10 +130,11 @@ def set_extent_xml(xml_in, xml_out, extent_xmin, extent_ymin, extent_xmax, exten
     print(f"File '{xml_out}' written")
 
 
-def modify_xml(xml_in, xml_out, extent_xmin=None, extent_ymin=None,
+def modify_xml(xml_in, xml_out, nb_bands, extent_xmin=None, extent_ymin=None,
                extent_xmax=None, extent_ymax=None):
-    """ Suppress cache tag and set extent in an xml file """
+    """ Suppress cache tag and set number of bands & extent in an xml file """
     suppress_cachetag(xml_in, xml_out)
+    set_nb_bands(xml_out, xml_out, nb_bands)
     if extent_xmin and extent_ymin and extent_xmax and extent_ymax:
         set_extent_xml(xml_out, xml_out, extent_xmin, extent_ymin, extent_xmax, extent_ymax)
     print(f"File '{xml_out}' written")
@@ -231,8 +245,12 @@ xml_from_wmts(wmts_graph, xml_graph_tmp)
 # suppress Cache tag and set extent
 xml_ortho = os.path.join(dirpath_out, 'ortho.xml')
 xml_graph = os.path.join(dirpath_out, 'graphe_surface.xml')
-modify_xml(xml_ortho_tmp, xml_ortho, bbox_xmin, bbox_ymin, bbox_xmax, bbox_ymax)
-modify_xml(xml_graph_tmp, xml_graph, bbox_xmin, bbox_ymin, bbox_xmax, bbox_ymax)
+# get number of channels or bands for ortho layer
+nb_bands_from_style = {'RVB': 3, 'IR': 1, 'IRC': 3}
+nb_bands_ortho = nb_bands_from_style.get(ARG.style_ortho)
+modify_xml(xml_ortho_tmp, xml_ortho, nb_bands_ortho, bbox_xmin, bbox_ymin, bbox_xmax, bbox_ymax)
+# graph layer is a RGB layer (3 channels)
+modify_xml(xml_graph_tmp, xml_graph, 3, bbox_xmin, bbox_ymin, bbox_xmax, bbox_ymax)
 # TODO: suppress xml ortho_tmp and graph_tmp - for now, useful for comparison
 
 # --------- create contours vrt from graph.xml -----------
@@ -269,7 +287,12 @@ if len(all_rband_tags) > 0:
                 ch = etree.SubElement(mdata, 'MDI', attrib={'key': key})
                 ch.text = val
             # add children tags ComplexSource for band 2 and 3
+            if rband.find('ComplexSource') is None and rband.find('SimpleSource') is None:
+                raise SystemExit(f"ERROR: Neither 'ComplexSource' tag, nor 'SimpleSource' \
+                                 could be found in '{vrt_tmp}' file")
             complsrc = rband.find('ComplexSource')
+            if complsrc is None and rband.find('SimpleSource') is not None:
+                complsrc = rband.find('SimpleSource')
             for i in range(2, 4):
                 tmp = deepcopy(complsrc)
                 srcband = tmp.find('SourceBand')

--- a/scripts/create_qgis_view.py
+++ b/scripts/create_qgis_view.py
@@ -491,7 +491,8 @@ if ARG.macros:
     # adapt macros to working data
     words_to_replace = {'__IDBRANCH__': branch_id,
                         '__URLSERVER__': ARG.url+'/',
-                        '__TILEMATRIXSET__': tms}
+                        '__TILEMATRIXSET__': tms,
+                        '__STYLE__': ARG.style_ortho}
     words_not_found = []
     with open(ARG.macros, 'r', encoding='utf-8') as file_macro_in:
         macros_data = file_macro_in.read()

--- a/scripts/create_qgis_view.py
+++ b/scripts/create_qgis_view.py
@@ -496,6 +496,7 @@ if ARG.macros:
                         '__URLSERVER__': ARG.url+'/',
                         '__TILEMATRIXSET__': tms,
                         '__STYLE__': ARG.style_ortho,
+                        '__CRS__': crs.postgisSrid(),
                         '__PIXELSIZEX__': pixel_size_x,
                         '__PIXELSIZEY__': pixel_size_y}
     words_not_found = []

--- a/scripts/create_qgis_view.py
+++ b/scripts/create_qgis_view.py
@@ -47,8 +47,9 @@ def read_args():
                         help='cache id',
                         type=int)
     parser.add_argument('-b', '--branch_name',
-                        help="name of new branch to be created on cache (default: newBranch)",
-                        type=str, default='newBranch')
+                        help="name of new branch to be created on cache",
+                        required=True,
+                        type=str)
     parser.add_argument('-s', '--style_ortho',
                         help="style for ortho to be exported to xml (default: RVB)",
                         type=str, default='RVB', choices=['RVB', 'IR', 'IRC'])

--- a/scripts/create_qgis_view.py
+++ b/scripts/create_qgis_view.py
@@ -344,6 +344,9 @@ set_layer_resampling(ortho_layer)
 # add to group
 ortho_group.insertChildNode(1, QgsLayerTreeLayer(ortho_layer))
 print_info_add_layer(ortho_lname)
+# get pixel size from layer
+pixel_size_x = round(ortho_layer.rasterUnitsPerPixelX(), 4)
+pixel_size_y = round(ortho_layer.rasterUnitsPerPixelY(), 4)
 # get crs from layer
 crs = ortho_layer.crs()
 # set project crs
@@ -492,7 +495,9 @@ if ARG.macros:
     words_to_replace = {'__IDBRANCH__': branch_id,
                         '__URLSERVER__': ARG.url+'/',
                         '__TILEMATRIXSET__': tms,
-                        '__STYLE__': ARG.style_ortho}
+                        '__STYLE__': ARG.style_ortho,
+                        '__PIXELSIZEX__': pixel_size_x,
+                        '__PIXELSIZEY__': pixel_size_y}
     words_not_found = []
     with open(ARG.macros, 'r', encoding='utf-8') as file_macro_in:
         macros_data = file_macro_in.read()


### PR DESCRIPTION
Évolution des scripts de création du cache : 
- activation des exceptions gdal/ogr, nécessaires surtout dans le cas de l'utilisation des calculs  via la gpao

 Évolutions du script de création de la vue QGIS :
-  changement en option obligatoire de l'option nom de la branche  (jusque-là, option facultative,  avec une valeur par défaut 'newBranch') 
-  prise en compte de nombre de canaux de l'ortho et du graphe dans la création des xml correspondants (au lieu de laisser la valeur par défaut "4")

Évolutions macros et de la vue de la vue QGIS  :  
- ajout de nouveaux paramètres à la macro : STYLE, PIXELSIZEX, PIXELSIZEY, CRS - jusque-là, ils avaient des valeurs en dur (style="RVB", pixel=0.05, crs="2154"), ce qui ne permettait pas de travailler, au moins pas facilement, avec des caches différents
- gestion de ces nouveaux paramètres de la macro dans la création de la vue