### PR TITLE
ci: upgrade python version

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.12.11
 
     - name: apt update
       run: |

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.12.11
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Utilisation d'une version plus récente pour python, car la version 3.8 n'est plus disponible pour ci