### PR TITLE
Fix "undefined" message

### DIFF
--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -160,11 +160,7 @@ class Editing {
       })
       .catch((error) => {
         console.log(error);
-        if (error === undefined) {
-          this.viewer.message = "'undefined' error";
-        } else {
-          this.viewer.message = error.message;
-        }
+        this.viewer.message = 'Erreur post patch';
         this.viewer.view.dispatchEvent({
           type: 'error',
           error,


### PR DESCRIPTION
Change the “undefined” message in the message section after an input error.

This was due to an incorrect function attribute call: “error.message” is incorrect; “error.msg” should have been called.
However, this message is the message displayed in the error pop-up shown just before. Furthermore, the message window is too small to display the entire error.

The choice made is to simply display the type of error that occurred.