### PR TITLE
Upgrade ci

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -34,7 +34,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install numpy
-        pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==`gdal-config --version`
+        pip install --config-settings="--global-option=build_ext" \
+            --config-settings="--global-option=-I/usr/include/gdal" \
+            GDAL==`gdal-config --version`
 
     - name: create cache RGB
       run: |

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.12.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: 3.12.11
+        python-version: 3.12
 
     - name: apt update
       run: |

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Caches:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
       run: |
         sudo apt-get update
     - name: Install gdal
-      # latest version of ubuntu (24.04) has only unstable ubuntugis release
+      # ubuntu 24.04 has only unstable ubuntugis release
       run: |
         sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable && sudo apt-get update
         sudo apt-get install python3-gdal

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.12.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: 3.12.11
+        python-version: 3.12
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Les tests ci ne fonctionnaient plus à cause notamment de la version de python qui n'était plus trouvée dans les dépôts car elle contenait le numéro du correctif qui est remplacé dans les dépôts quand un nouveau apparaît.

Les modifications apportées pour que les tests ci refonctionnent :
- mis à jour la version python en gardant seulement le numéro de version majeure et mineure pour plus de stabilité et souplesse 
- mis à jour les options de config gdal dans pip qui étaient devenues obsolètes et qui ne fonctionnaient plus avec les nouvelles versions de pip > 23.3

J'ai aussi figé la version d'ubuntu pour le docker ci pour mieux gérer les versions des paquets et ne pas avoir des surprises avec les versions imposées par "latest".

Avec les nouvelles versions de python, gdal etc. les tests passent, les scripts python de création/update cache sont validées, mais je vois qu'ils ont des messages avec des exceptions qui ne les empêchent pas d'arriver au bout du calcul et de générer des caches valides, ce qui fait que les tests passent. Comme cela n'est pas lié au ci, je propose de les gérer plus tard dans une autre PR.