### PR TITLE
Correction bug sur les caches IR où juste l'ortho n'était pas mise à jour dans la vue

### DIFF
--- a/middlewares/wmts.js
+++ b/middlewares/wmts.js
@@ -232,13 +232,14 @@ function wmts(req, _res, next) {
       }
       const cogDirUrl = path.join(req.dir_cache, layerName, cogPath.dirPath);
       let cogUrl = path.join(cogDirUrl, `${cogOrigFilename}.tif`);
-      const cogRgbUrl = path.join(cogDirUrl, `${cogRgbFilename}.tif`);
-      const cogIrUrl = path.join(cogDirUrl, `${cogIrFilename}.tif`);
       // S'il y a une image avec saisie, il faut prend celle-ci
-      debug('cogUrl :', cogUrl, 'cogRgbUrl: ', cogRgbUrl, 'cogIrUrl: ', cogIrUrl);
-      if (fs.existsSync(cogRgbUrl) || fs.existsSync(cogIrUrl)) {
+
+      debug('cogDirUrl:', cogDirUrl, 'cogOrigFilename: ', cogOrigFilename,
+        'cogRgbFilename: ', cogRgbFilename, 'cogIrFilename: ', cogIrFilename);
+      if (fs.existsSync(path.join(cogDirUrl, `${cogRgbFilename}.tif`))
+          || fs.existsSync(path.join(cogDirUrl, `${cogIrFilename}.tif`))) {
         debug('version branche');
-        cogUrl = cogRgbUrl;
+        cogUrl = path.join(cogDirUrl, `${cogRgbFilename}.tif`);
       } else {
         debug('version orig');
       }

--- a/middlewares/wmts.js
+++ b/middlewares/wmts.js
@@ -217,30 +217,28 @@ function wmts(req, _res, next) {
     }
     try {
       const cogPath = cog.getTileInfo(TILECOL, TILEROW, TILEMATRIX, overviews);
-      const cogDirUrl = path.join(req.dir_cache,
-        layerName,
-        cogPath.dirPath);
-      let cogNameRVB = `${idBranch}_${cogPath.filename}`;
-      let cogNameIR = `${cogNameRVB}i`;
-      let cogNameOrig = `${cogPath.filename}`;
+      let cogRgbFilename = `${idBranch}_${cogPath.filename}`;
+      let cogIrFilename = `${cogRgbFilename}i`;
+      let cogOrigFilename = `${cogPath.filename}`;
       if (LAYER === 'opi') {
         if (!Name) {
           [Name] = Object.keys(overviews.list_OPI);
         }
         debugGetTile('Name : ', Name);
-        cogNameOrig += `_${Name}`;
+        cogOrigFilename += `_${Name}`;
         // Pas de gestion de branche pour les OPI
-        cogNameRVB = cogNameOrig;
-        cogNameIR = cogNameOrig.replace('x', '_ix');
+        cogRgbFilename = cogOrigFilename;
+        cogIrFilename = cogOrigFilename.replace('x', '_ix');
       }
-      let cogUrl = path.join(cogDirUrl, `${cogNameOrig}.tif`);
-      const cogUrlRVB = path.join(cogDirUrl, `${cogNameRVB}.tif`);
-      const cogUrlIR = path.join(cogDirUrl, `${cogNameIR}.tif`);
-      // si jamais la version de la branche existe, c'est elle qu'il faut utiliser
-      debug('cogUrl :', cogUrl, 'cogUrlRVB: ', cogUrlRVB, 'cogUrlIR: ', cogUrlIR);
-      if (fs.existsSync(cogUrlRVB) || fs.existsSync(cogUrlIR)) {
+      const cogDirUrl = path.join(req.dir_cache, layerName, cogPath.dirPath);
+      let cogUrl = path.join(cogDirUrl, `${cogOrigFilename}.tif`);
+      const cogRgbUrl = path.join(cogDirUrl, `${cogRgbFilename}.tif`);
+      const cogIrUrl = path.join(cogDirUrl, `${cogIrFilename}.tif`);
+      // S'il y a une image avec saisie, il faut prend celle-ci
+      debug('cogUrl :', cogUrl, 'cogRgbUrl: ', cogRgbUrl, 'cogIrUrl: ', cogIrUrl);
+      if (fs.existsSync(cogRgbUrl) || fs.existsSync(cogIrUrl)) {
         debug('version branche');
-        cogUrl = cogUrlRVB;
+        cogUrl = cogRgbUrl;
       } else {
         debug('version orig');
       }

--- a/middlewares/wmts.js
+++ b/middlewares/wmts.js
@@ -217,30 +217,30 @@ function wmts(req, _res, next) {
     }
     try {
       const cogPath = cog.getTileInfo(TILECOL, TILEROW, TILEMATRIX, overviews);
-      let urlBranch = path.join(req.dir_cache,
+      const cogDirUrl = path.join(req.dir_cache,
         layerName,
-        cogPath.dirPath,
-        `${idBranch}_${cogPath.filename}`);
-      let url = path.join(req.dir_cache,
-        layerName,
-        cogPath.dirPath,
-        `${cogPath.filename}`);
+        cogPath.dirPath);
+      let cogNameRVB = `${idBranch}_${cogPath.filename}`;
+      let cogNameIR = `${cogNameRVB}i`;
+      let cogNameOrig = `${cogPath.filename}`;
       if (LAYER === 'opi') {
         if (!Name) {
           [Name] = Object.keys(overviews.list_OPI);
         }
         debugGetTile('Name : ', Name);
-        url += `_${Name}`;
+        cogNameOrig += `_${Name}`;
         // Pas de gestion de branche pour les OPI
-        urlBranch = url;
+        cogNameRVB = cogNameOrig;
+        cogNameIR = cogNameOrig.replace('x', '_ix');
       }
-      urlBranch += '.tif';
-      url += '.tif';
+      let cogUrl = path.join(cogDirUrl, `${cogNameOrig}.tif`);
+      const cogUrlRVB = path.join(cogDirUrl, `${cogNameRVB}.tif`);
+      const cogUrlIR = path.join(cogDirUrl, `${cogNameIR}.tif`);
       // si jamais la version de la branche existe, c'est elle qu'il faut utiliser
-      debug(url, urlBranch);
-      if (fs.existsSync(urlBranch)) {
+      debug('cogUrl :', cogUrl, 'cogUrlRVB: ', cogUrlRVB, 'cogUrlIR: ', cogUrlIR);
+      if (fs.existsSync(cogUrlRVB) || fs.existsSync(cogUrlIR)) {
         debug('version branche');
-        url = urlBranch;
+        cogUrl = cogUrlRVB;
       } else {
         debug('version orig');
       }
@@ -258,7 +258,7 @@ function wmts(req, _res, next) {
           break;
         default:
       }
-      gdalProcessing.getTileEncoded(url,
+      gdalProcessing.getTileEncoded(cogUrl,
         cogPath.x, cogPath.y, cogPath.z,
         formatGDAL, overviews.tileSize.width, bands)
         .then((img) => {

--- a/middlewares/wmts.js
+++ b/middlewares/wmts.js
@@ -220,13 +220,15 @@ function wmts(req, _res, next) {
       let cogRgbFilename = `${idBranch}_${cogPath.filename}`;
       let cogIrFilename = `${cogRgbFilename}i`;
       let cogOrigFilename = `${cogPath.filename}`;
+      // Cas des opi:
+      // Les opis ne sont jamais modifier par une saisie ou une branche
+      // il faut donc prend ceux d'origine en RVB et IR
       if (LAYER === 'opi') {
         if (!Name) {
           [Name] = Object.keys(overviews.list_OPI);
         }
         debugGetTile('Name : ', Name);
         cogOrigFilename += `_${Name}`;
-        // Pas de gestion de branche pour les OPI
         cogRgbFilename = cogOrigFilename;
         cogIrFilename = cogOrigFilename.replace('x', '_ix');
       }

--- a/middlewares/wmts.js
+++ b/middlewares/wmts.js
@@ -232,10 +232,13 @@ function wmts(req, _res, next) {
       }
       const cogDirUrl = path.join(req.dir_cache, layerName, cogPath.dirPath);
       let cogUrl = path.join(cogDirUrl, `${cogOrigFilename}.tif`);
-      // S'il y a une image avec saisie, il faut prend celle-ci
 
       debug('cogDirUrl:', cogDirUrl, 'cogOrigFilename: ', cogOrigFilename,
         'cogRgbFilename: ', cogRgbFilename, 'cogIrFilename: ', cogIrFilename);
+      // On teste la présence de fichiers avec saisie en RVB et IR, pour gérer les
+      // caches juste RVB ou juste IR. Par la suite, on ne garde que le chemin RVB
+      // car dans gdalProcessing.getTileEncoded, il recalcule le chemin IR et ne
+      // prend en compte que les fichiers présents.
       if (fs.existsSync(path.join(cogDirUrl, `${cogRgbFilename}.tif`))
           || fs.existsSync(path.join(cogDirUrl, `${cogIrFilename}.tif`))) {
         debug('version branche');


### PR DESCRIPTION
Bug présent sur master v2.4.2

Correction d'un bug sur les caches IR où juste l'ortho n'était pas mise à jour dans la vue après une saisie (le graph et le contour étaient bien mise à jour dans le vue), alors que l'ortho était bien calculée et présente dans le cache. C'était tout le temps l'ortho d'origine qui était afficher.
Le bug était dû lors de la récupération des tuiles par `GetTile` de wmts qui vérifiait que la présence de nouvelles tuiles RVB et non IR. 
Correction en ajoutant à la vérification déjà existante, une vérification de la présence de nouvelles tuiles IR.