### PR TITLE
Résolution du rafraichissement des tuiles sur le client itowns après une saisie

### DIFF
--- a/itowns/Editing.js
+++ b/itowns/Editing.js
@@ -152,7 +152,8 @@ class Editing {
     // On post le geojson sur l'API
     this.api.postPatch(this.branch.active.id, JSON.stringify(geojson))
       .then(() => {
-        this.viewer.refresh(['Ortho', 'Graph', 'Contour', 'Patches']);
+        const cacheBusting = true;
+        this.viewer.refresh(['Ortho', 'Graph', 'Contour', 'Patches'], cacheBusting);
         this.viewer.message = '';
       })
       .catch((error) => {
@@ -573,7 +574,8 @@ class Editing {
       this.view.controls.setCursor('default', 'auto');
       this.currentStatus = status.RAS;
       if (res.status === 200) {
-        this.view.refresh(['Ortho', 'Graph', 'Contour', 'Patches']);
+        const cacheBusting = true;
+        this.view.refresh(['Ortho', 'Graph', 'Contour', 'Patches'], cacheBusting);
       }
       res.text().then((msg) => {
         this.viewer.message = msg;
@@ -600,7 +602,8 @@ class Editing {
       this.view.controls.setCursor('default', 'auto');
       this.currentStatus = status.RAS;
       if (res.status === 200) {
-        this.viewer.refresh(this.branch.layers);
+        const cacheBusting = true;
+        this.viewer.refresh(this.branch.layers, cacheBusting);
       }
       res.text().then((msg) => {
         this.viewer.message = msg;

--- a/itowns/Viewer.js
+++ b/itowns/Viewer.js
@@ -298,7 +298,7 @@ class Viewer {
     });
   }
 
-  refresh(layers) {
+  refresh(layers, cacheBusting = false) {
     const layerList = layers instanceof Array ? layers : [layers];
     const layerNames = [];
     layerList.forEach((layer) => {
@@ -339,6 +339,10 @@ class Viewer {
             }
             changeLayerStyle(config, layer.idSelected, this.oldStyle[layerName]);
           }
+        } else if (cacheBusting) {
+          // Force cache-busting pour les couches WMTS raster (Ortho, Graph, ...)
+          // by adding a new parameter
+          config.source.url = `${layer.source.url.replace(/[&?]t=\d+/, '')}&t=${Date.now()}`;
         }
         this.view.removeLayer(layerName);
       } else {


### PR DESCRIPTION
Problème:
Les couches WMTS sur iTowns ne se mettait plus à jour sur la vue après la correction du graph par une saisie. présent sur la branche `master` et `2Opi`

Résolution avec IA Claude.

Pourquoi:
Cela été dû au cache comme les urls des nouvelles images été identique au ancienne, elle n'était pas chargé par iTowns.
Explication IA Claude : "Dans Viewer.js:refresh(), les couches raster WMTS (Ortho, Graph) étaient recréées avec le même objet WMTSSource — iTowns réutilisait donc son cache interne des tuiles et ne re-demandait rien au serveur. Les couches vectorielles elles, créaient une nouvelle FileSource, ce qui forçait un re-fetch.".

Correction:
Lors du rafraichissement de la vue, on force la recharge des nouvelles images, grâce à l'attribut de la date.
Explication IA Claude: "Quand la couche est WMTS (non vectorielle), on ajoute/met à jour un paramètre &t=<timestamp> sur l'URL de la source avant de supprimer et recréer la couche. Cela force le navigateur et iTowns à considérer l'URL comme nouvelle et à re-télécharger les tuiles depuis le serveur.".

Après plusieurs tests cela corrige bien le rafraichissement des tuiles dans la vue iTowns.