### PR TITLE
fix(cache,API): set graph colorInterp from undefined to rgb

### DIFF
--- a/gdal_processing.js
+++ b/gdal_processing.js
@@ -267,6 +267,9 @@ function processPolygonPatchAsync(patch, blocSize) {
         graph.size.x, graph.size.y, graph.bands[1]);
       graphMem.bands.get(3).pixels.write(0, 0,
         graph.size.x, graph.size.y, graph.bands[2]);
+      graphMem.bands.get(1).colorInterpretation = gdal.GCI_RedBand;
+      graphMem.bands.get(2).colorInterpretation = gdal.GCI_GreenBand;
+      graphMem.bands.get(3).colorInterpretation = gdal.GCI_BlueBand;
       const orthoRgbMem = orthoRgb ? gdal.open('orthoRgb', 'w', 'MEM',
         orthoRgb.size.x, orthoRgb.size.y, 3) : null;
       if (orthoRgbMem) {

--- a/scripts/cache_def.py
+++ b/scripts/cache_def.py
@@ -463,6 +463,9 @@ def create_ortho_and_graph_1arg(arg):
                                                    "COMPRESS=LZW",
                                                    "RESAMPLING=NEAREST",
                                                    "PREDICTOR=YES"])
+        dst_graph.GetRasterBand(1).SetColorInterpretation(gdal.GCI_RedBand)
+        dst_graph.GetRasterBand(2).SetColorInterpretation(gdal.GCI_GreenBand)
+        dst_graph.GetRasterBand(3).SetColorInterpretation(gdal.GCI_BlueBand)
 
         dst_graph = None  # noqa: F841
         # pylint: enable=unused-variable


### PR DESCRIPTION
Correction dans la création du cache et dans l'API pour que :
-  les dalles de graphe soient générées en "RGB" au lieu de "Undefined"
-  les dalles de graphe impactées par des saisies manuelles (polygones) soient aussi en "RGB" au lieu de "Undefined" (les dalles de graphe impactées par une saisie semi-auto étaient déjà générées en RGB)

Cela rend homogènes les dalles de graphe d'origine (sans saisie) et celles impactées par des saisies (corrigeant ainsi le problème lors de l'export du graphe).

Ce problème existait très probablement depuis le début, la dernière version de master (v2.4.2) incluse.

La branche a été testée et validée par AC et le client final (équipe de GM)