### PR TITLE
Correction de l'utilisation de applyPatch dans rebase 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,12 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
+    'no-restricted-syntax': [ // supression ForOfStatement pour autorisé for...of sur des tables
+      'error',
+      'ForInStatement',
+      'LabeledStatement',
+      'WithStatement',
+    ],
+    'no-await-in-loop': 'off',
   },
 };

--- a/middlewares/branch.js
+++ b/middlewares/branch.js
@@ -181,11 +181,9 @@ async function rebase(req, res, next) {
       });
     });
     // on ajoute les patchs dans la BD sur cette nouvelle branche
-    /* eslint-disable-next-line */
     for (const feature of patches.features) {
       // on insert ce patch dans les MTD de la branche
       debug(feature.properties);
-      /* eslint-disable-next-line */
       const patchInserted = await db.insertPatch(req.client,
         idNewBranch,
         feature.geometry,
@@ -196,15 +194,9 @@ async function rebase(req, res, next) {
         feature.properties.is_auto);
       const idNewPatch = patchInserted.id_patch;
 
-      const slabs = [];
-
-      /* eslint-disable-next-line */
-      for (const s of feature.properties.slabs) {
-        slabs.push({ x: s[0], y: s[1], z: s[2] });
-      }
+      const slabs = feature.properties.slabs.map((s) => ({ x: s[0], y: s[1], z: s[2] }));
 
       // ajouter les slabs correspondant au patch dans la table correspondante
-      /* eslint-disable-next-line */
       await db.insertSlabs(req.client, idNewPatch, slabs);
     }
   } catch (error) {

--- a/middlewares/branch.js
+++ b/middlewares/branch.js
@@ -220,23 +220,24 @@ async function rebase(req, res, next) {
   await db.beginTransaction(req.client);
   // on retourne l'identifiant de la branche, son nom et l'identifiant et du processus
   req.result = { json: { name, id: idNewBranch, idProcess }, code: 200 };
-  next();
   // a partir de d'ici c'est non bloquant
   try {
     const patches = await db.getActivePatches(req.client, idBranch);
     debug('patches : ', patches);
 
     debug('>>applyPatches', patches.features);
-    patches.features.forEach(async (feature) => {
-      debug('application de ', feature);
+    // Clonage du patches pour en modifier un
+    const patchWithOneFeature = JSON.parse(JSON.stringify(patches));
+    for (const feature of patches.features) {
+      patchWithOneFeature.features = [feature];
       await patch.applyPatch(
         req.client,
         req.overviews,
         cache.path,
         idNewBranch,
-        feature,
+        patchWithOneFeature,
       );
-    });
+    }
     debug('fin de applyPatches');
 
     await db.finishProcess(req.client, 'succeed', idProcess, 'done');
@@ -245,6 +246,7 @@ async function rebase(req, res, next) {
     await db.finishProcess(req.client, 'failed', idProcess, 'done');
   }
   pgClient.close(req, res, () => {});
+  next();
 }
 
 async function getCachePath(req, _res, next) {

--- a/regress/test-API/3_branch.js
+++ b/regress/test-API/3_branch.js
@@ -286,7 +286,7 @@ describe('route/branch.js', () => {
               //   });
               done();
             });
-        });
+        }).timeout(9000);
       });
       describe('with patch', () => {
         describe(`add a patch on ${branchName}`, () => {
@@ -352,7 +352,7 @@ describe('route/branch.js', () => {
                 //     done();
                 //   });
               });
-          });
+          }).timeout(9000);
         });
         describe(`rebase 'orig' into ${branchName}`, () => {
           it('should succeed', (done) => {
@@ -388,7 +388,7 @@ describe('route/branch.js', () => {
               //       done();
               //     });
               });
-          });
+          }).timeout(9000);
         });
       });
     });


### PR DESCRIPTION
La fonction rebase à trois erreurs de traitements, dont une présente sur master v2.4.2 (1):

1. Un problème de nom de clé: l'appel de la clé 'opiName' n’existe pas dans les 'properties' des patchs récupérer car dans la requête sql, la clé 'opiName' est transfomé en 'opiname' -> correction déjà réalisé dans le commit e2bd259 ("refactor(API,monitor): change geojson tags to match those of ccpexe", 2026-03-05)

2. Un problème de paramètre changer dans apllyPatch introduit dans 2Opi (f01431a ("feat(api:middlewares/patch): add semi auto patch with ozcpp.exe", 2025-07-30)) qui est corrigé dans cette PR

Le problème d'argument était dû à la passation du geojson de saisie en entier dans applyPatch au lieu de juste la feature voulue, (on a besoin du geojson en entier pour les saisie semi-auto avec les polylignes.

Correction: reconstruction du geojson dans le rebase avec juste la saisie à appliquer, qui est mis en paramètre de applyPatch 

3. Un problème de gestion de temps, dans rebase il y a un 'next' après initialisation de la nouvelle branche avec les patchs de la branche de base, juste avant d'appliquer les patchs de l'autre branche. Ce 'next' enlève une partie du traitement dans l'attente/validation que le rebase est fini, ce qui génère des incohérence car le swagger dit que c'est bon alors que l'api tourne toujours pour appliquer les patchs de la branche en cour de rebase. 

Correction: déplacement du 'next' à la fin de la fonction rebase et ajout d'un timeout au test pour pas qu'il échoue à cause du temps